### PR TITLE
Paper: Clarify Design Authority (old folder is full spec)

### DIFF
--- a/docs/paper/chapters/00-preface.md
+++ b/docs/paper/chapters/00-preface.md
@@ -39,6 +39,19 @@ Version 3.0RC1
   - [Appendix B: Diagnostic Tooling and Control](appendix-b-diagnostic-tooling-and-control.md)
   - [Appendix C: Bibliography / Reading List](appendix-c-bibliography-reading-list.md)
 
+## Design Reference & Authority
+This paper documents the Esper‑Lite prototype and aligns with the broader Esper system design. The “old” directory under `docs/design/detailed_design/old/` is not deprecated; it contains the full, more detailed system definition. Where any divergence exists, treat those detailed design files as authoritative, and update this paper accordingly.
+
+| Topic                        | Primary Design Reference                                             | Notes |
+|-----------------------------|-----------------------------------------------------------------------|-------|
+| High‑Level Architecture     | `docs/design/HLD.md`                                                 | Subsystems, planes, interaction flow |
+| Leyline Contracts & Budgets | `docs/design/detailed_design/00-leyline.md`                          | Option B budgets, schemas, governance |
+| Kasmina Lifecycle & Safety  | `docs/design/detailed_design/02-kasmina.md` and `old/02-kasmina-*.md`| 11‑state lifecycle, guards, circuit breakers |
+| Tamiyo Policy & Risk        | `docs/design/detailed_design/03-tamiyo.md` and `old/03-tamiyo-*.md`  | Hetero‑GNN policy, risk governance, field reports |
+| Telemetry & Observability   | `old/10-nissa-unified-design.md` (referenced)                         | SLOs, telemetry routing |
+
+Scope: Esper‑Lite implements the minimal, production‑safe slice of the full Esper architecture. This paper’s prototype examples (e.g., XOR, make_moons) illustrate the morphogenetic lifecycle without the full kernel compilation and governance stack; production behaviour follows the detailed design.
+
 ## Abstract
 This document outlines the formal groundwork and technical scaffolding for a class of neural architectures capable of localised, seed-driven structural evolution within frozen host networks. The approach—referred to as morphogenetic architecture—enables the introduction of trainable components that can independently develop new capabilities in response to local failure signals or performance deficits.
 The central concept is that of a seed: a compact, parameter-initialised tensor or module with the capacity to 'germinate'—that is, instantiate and integrate new trainable subnetworks into a frozen model context. This strategy allows targeted increases in representational or task-specific capacity without retraining the global model.


### PR DESCRIPTION
Adds Preface section clarifying that docs/design/detailed_design/old is not deprecated; it contains the full, more detailed system definition and is authoritative. Includes reference map and scope note.\n\nDocs only; no code changes.