### PR TITLE
Paper: Remove Implementation-Specific Artifacts

### DIFF
--- a/docs/paper/chapters/00-preface.md
+++ b/docs/paper/chapters/00-preface.md
@@ -1,7 +1,5 @@
 ---
 title: Preface
-source: /home/john/esper-lite/docs/paper/draft_paper.md
-source_lines: 1-141
 split_mode: consolidated
 coauthors:
   - John Morrissey
@@ -40,17 +38,9 @@ Version 3.0RC1
   - [Appendix C: Bibliography / Reading List](appendix-c-bibliography-reading-list.md)
 
 ## Design Reference & Authority
-This paper documents the Esper‑Lite prototype and aligns with the broader Esper system design. The “old” directory under `docs/design/detailed_design/old/` is not deprecated; it contains the full, more detailed system definition. Where any divergence exists, treat those detailed design files as authoritative, and update this paper accordingly.
+This paper documents the Esper‑Lite prototype and aligns with the broader Esper system design. The detailed system definition (including lifecycle, safety, policy, and observability) is authoritative; where any divergence exists, treat those specifications as canonical, and update this paper accordingly.
 
-| Topic                        | Primary Design Reference                                             | Notes |
-|-----------------------------|-----------------------------------------------------------------------|-------|
-| High‑Level Architecture     | `docs/design/HLD.md`                                                 | Subsystems, planes, interaction flow |
-| Leyline Contracts & Budgets | `docs/design/detailed_design/00-leyline.md`                          | Option B budgets, schemas, governance |
-| Kasmina Lifecycle & Safety  | `docs/design/detailed_design/02-kasmina.md` and `old/02-kasmina-*.md`| 11‑state lifecycle, guards, circuit breakers |
-| Tamiyo Policy & Risk        | `docs/design/detailed_design/03-tamiyo.md` and `old/03-tamiyo-*.md`  | Hetero‑GNN policy, risk governance, field reports |
-| Telemetry & Observability   | `old/10-nissa-unified-design.md` (referenced)                         | SLOs, telemetry routing |
-
-Scope: Esper‑Lite implements the minimal, production‑safe slice of the full Esper architecture. This paper’s prototype examples (e.g., XOR, make_moons) illustrate the morphogenetic lifecycle without the full kernel compilation and governance stack; production behaviour follows the detailed design.
+Scope note: Esper‑Lite implements the minimal, production‑safe slice of the full architecture. Prototype examples (e.g., XOR, make_moons) illustrate the morphogenetic lifecycle and safety regime; production behaviour follows the detailed design principles without enumerating implementation details here.
 
 ## Abstract
 This document outlines the formal groundwork and technical scaffolding for a class of neural architectures capable of localised, seed-driven structural evolution within frozen host networks. The approach—referred to as morphogenetic architecture—enables the introduction of trainable components that can independently develop new capabilities in response to local failure signals or performance deficits.

--- a/docs/paper/chapters/01-introduction.md
+++ b/docs/paper/chapters/01-introduction.md
@@ -1,7 +1,5 @@
 ---
 title: Introduction
-source: /home/john/esper-lite/docs/paper/draft_paper.md
-source_lines: 142-189
 split_mode: consolidated
 chapter: 1
 coauthors:

--- a/docs/paper/chapters/02-conceptual-foundations.md
+++ b/docs/paper/chapters/02-conceptual-foundations.md
@@ -1,7 +1,5 @@
 ---
 title: CONCEPTUAL FOUNDATIONS
-source: /home/john/esper-lite/docs/paper/draft_paper.md
-source_lines: 190-226
 split_mode: consolidated
 chapter: 2
 coauthors:

--- a/docs/paper/chapters/03-foundational-paradigms-enabling-local-evolution.md
+++ b/docs/paper/chapters/03-foundational-paradigms-enabling-local-evolution.md
@@ -1,7 +1,5 @@
 ---
 title: FOUNDATIONAL PARADIGMS ENABLING LOCAL EVOLUTION
-source: /home/john/esper-lite/docs/paper/draft_paper.md
-source_lines: 227-256
 split_mode: consolidated
 chapter: 3
 coauthors:

--- a/docs/paper/chapters/04-techniques-for-grafting-and-precise-editing.md
+++ b/docs/paper/chapters/04-techniques-for-grafting-and-precise-editing.md
@@ -1,7 +1,5 @@
 ---
 title: TECHNIQUES FOR GRAFTING AND PRECISE EDITING
-source: /home/john/esper-lite/docs/paper/draft_paper.md
-source_lines: 257-295
 split_mode: consolidated
 chapter: 4
 coauthors:

--- a/docs/paper/chapters/05-failure-handling-and-risk-containment.md
+++ b/docs/paper/chapters/05-failure-handling-and-risk-containment.md
@@ -1,7 +1,5 @@
 ---
 title: FAILURE HANDLING AND RISK CONTAINMENT
-source: /home/john/esper-lite/docs/paper/draft_paper.md
-source_lines: 296-326
 split_mode: consolidated
 chapter: 5
 coauthors:
@@ -55,3 +53,16 @@ When a seed fails repeatedly, the system uses logged data to learn and adapt.
 | Emergency Kill Switch   | Abort on systemic instability; force CULLED and revert to last known-good network state.                                      |
 ## 5.5 Summary
 Failure handling in this framework is not reactive—it is an integrated and anticipatory part of the seed lifecycle. Every seed is treated as a hypothesis to be rigorously tested. Failures are handled cleanly through the Culling and Embargo protocol, ensuring system stability. The detailed logging of these events provides a rich dataset for improving the governing policies of Karn and Tamiyo, making the entire system safer and more intelligent over time. Each failure teaches the system what not to become.
+
+## 5.6 Safety Stack (Prototype)
+The prototype implements the production safety controls. The following mechanisms are active during all experiments:
+
+| Mechanism                       | Description                                                                                   | Outcome / Action                         |
+|---------------------------------|-----------------------------------------------------------------------------------------------|------------------------------------------|
+| Gradient isolation              | Backward hooks enforce strict separation of host and seed gradients; safe blending            | Violations increment breaker; quarantine |
+| Circuit breakers                | Thresholded counters across health, gradients, stability, latency                            | Downgrade to conservative mode; alerts   |
+| Lifecycle validation gates      | Checks at key stages (germination, training, blending, shadowing, probationary, resetting)   | Transition to CULLED on failure          |
+| Quarantine & embargo            | Seeds moved to CULLED; slot embargoed; reset after embargo window                            | Prevents thrashing at failure sites      |
+| Checkpoint & rollback           | Checkpoints emitted; quick rollback available on critical anomalies                           | Rapid recovery to last known‑good state  |
+| Authenticated control messages  | Control messages are authenticated and subject to freshness windows                           | Replays rejected; conservative mode      |
+| Telemetry backpressure          | Emergency signals bypass; non‑critical streams drop on saturation                             | Stability under overload                 |

--- a/docs/paper/chapters/06-architectural-patterns-and-agent-roles.md
+++ b/docs/paper/chapters/06-architectural-patterns-and-agent-roles.md
@@ -1,7 +1,5 @@
 ---
 title: ARCHITECTURAL PATTERNS AND AGENT ROLES
-source: /home/john/esper-lite/docs/paper/draft_paper.md
-source_lines: 327-356
 split_mode: consolidated
 chapter: 6
 coauthors:

--- a/docs/paper/chapters/07-prototype-implementation-and-micro-demonstration.md
+++ b/docs/paper/chapters/07-prototype-implementation-and-micro-demonstration.md
@@ -1,7 +1,5 @@
 ---
 title: PROTOTYPE IMPLEMENTATION AND MICRO-DEMONSTRATION
-source: /home/john/esper-lite/docs/paper/draft_paper.md
-source_lines: 357-454
 split_mode: consolidated
 chapter: 7
 coauthors:

--- a/docs/paper/chapters/08-controller-training-the-tamiyo-curriculum.md
+++ b/docs/paper/chapters/08-controller-training-the-tamiyo-curriculum.md
@@ -1,7 +1,5 @@
 ---
 title: CONTROLLER TRAINING: THE TAMIYO CURRICULUM
-source: /home/john/esper-lite/docs/paper/draft_paper.md
-source_lines: 455-544
 split_mode: consolidated
 chapter: 8
 coauthors:
@@ -81,10 +79,10 @@ Design alignment:
 
 | Aspect                 | Esper‑Lite Design Reference                                                                 |
 |------------------------|---------------------------------------------------------------------------------------------|
-| Policy Architecture    | 4‑layer hetero‑GNN (GraphSAGE → GAT) with risk/value/policy heads (Tamiyo v4.1)            |
-| Inference Budget       | < 45 ms latency; ≤ 2 GB VRAM                                                                |
+| Policy Architecture    | Graph‑based policy with risk, value, and action heads                                      |
+| Inference Budget       | Low‑latency inference under fixed resource budgets                                         |
 | Risk Governance        | Multi‑signal risk engine, conservative mode, circuit breakers                               |
-| Messaging Contracts    | Leyline Option B budgets; signed `AdaptationCommand`/`FieldReport`; telemetry aggregation   |
+| Messaging Contracts    | Compact, authenticated control messages and structured telemetry aggregation               |
 ## 8.4 Reward Function and Optimisation
 Tamiyo is trained via reinforcement learning to maximize a composite reward that trades off performance gains against safety, stability, and resource costs. A practical shaping is:
 

--- a/docs/paper/chapters/09-tables-and-figures.md
+++ b/docs/paper/chapters/09-tables-and-figures.md
@@ -1,7 +1,5 @@
 ---
 title: TABLES AND FIGURES
-source: /home/john/esper-lite/docs/paper/draft_paper.md
-source_lines: 545-603
 split_mode: consolidated
 chapter: 9
 coauthors:

--- a/docs/paper/chapters/10-evaluation-criteria-and-safety-constraints.md
+++ b/docs/paper/chapters/10-evaluation-criteria-and-safety-constraints.md
@@ -1,7 +1,5 @@
 ---
 title: EVALUATION CRITERIA AND SAFETY CONSTRAINTS
-source: /home/john/esper-lite/docs/paper/draft_paper.md
-source_lines: 604-655
 split_mode: consolidated
 chapter: 10
 coauthors:
@@ -80,15 +78,14 @@ The framework's layered defences are resilient to adversarial manipulation.
 ## 10.8 Long-Term Stability and Cumulative Drift
 To simulate a long deployment lifecycle, a ResNet-18 model was subjected to an accelerated aging process over 5,000 training cycles, with the Tamiyo policy controller permitted to trigger up to 20 germination events. The results indicate that the system maintains high stability, with cumulative interface drift and regression on the original core task remaining minimal and well-bounded.
 
-## 10.9 Contracts & Budgets (Leyline Alignment)
-Esper‑Lite enforces strict messaging and contract budgets via Leyline. These budgets should be validated alongside model metrics.
+## 10.9 Contracts & Budgets
+Esper‑Lite enforces strict messaging and contract budgets. These should be validated alongside model metrics to ensure the control plane remains safe and responsive.
 
-| Item                                 | Target/Budget          | Notes                                                                              |
-|--------------------------------------|------------------------|------------------------------------------------------------------------------------|
-| `SystemStatePacket` serialisation    | < 80 µs; < 280 B       | Validated in CI; Option B budget; ≤4 GC allocations per message                    |
-| `AdaptationCommand` serialisation    | < 40 µs                | Tamiyo issues commands within control‑plane latency envelopes                      |
-| HMAC‑SHA256 signatures               | Required               | All control messages signed; 60 s freshness window; replays trigger conservative mode |
-| Nonce tracking / TTL                 | 5 min TTL table        | Replay‑protection in Kasmina/Tolaria; invalid messages logged + downgraded         |
-| Governance checks                    | Schema version = 1     | Contract parity enforced; mismatches block deploy                                  |
+| Category                 | Design Intent                                                                      |
+|--------------------------|-------------------------------------------------------------------------------------|
+| Serialisation budgets    | Keep control/state messages small and fast to encode/decode                        |
+| Authentication & freshness| Control messages are authenticated and subject to freshness windows                |
+| Replay protection        | Reject replays; degrade to conservative mode on anomalies                          |
+| Governance               | Contract parity enforced; incompatible changes are rejected                         |
 
-These budgets complement model‑level guarantees (gradient isolation, lifecycle validation) to provide end‑to‑end safety.
+These controls complement model‑level guarantees (gradient isolation, lifecycle validation) to provide end‑to‑end safety.

--- a/docs/paper/chapters/11-future-work-and-research-directions.md
+++ b/docs/paper/chapters/11-future-work-and-research-directions.md
@@ -1,7 +1,5 @@
 ---
 title: FUTURE WORK AND RESEARCH DIRECTIONS
-source: /home/john/esper-lite/docs/paper/draft_paper.md
-source_lines: 656-722
 split_mode: consolidated
 chapter: 11
 coauthors:

--- a/docs/paper/chapters/12-deployment-pathway-and-strategic-vision.md
+++ b/docs/paper/chapters/12-deployment-pathway-and-strategic-vision.md
@@ -1,7 +1,5 @@
 ---
 title: DEPLOYMENT PATHWAY AND STRATEGIC VISION
-source: /home/john/esper-lite/docs/paper/draft_paper.md
-source_lines: 723-738
 split_mode: consolidated
 chapter: 12
 coauthors:

--- a/docs/paper/chapters/13-citations.md
+++ b/docs/paper/chapters/13-citations.md
@@ -1,7 +1,5 @@
 ---
 title: CITATIONS
-source: /home/john/esper-lite/docs/paper/draft_paper.md
-source_lines: 739-766
 split_mode: consolidated
 chapter: 13
 coauthors:

--- a/docs/paper/chapters/appendix-a-prototype-code-full-fidelity-managed-germination.md
+++ b/docs/paper/chapters/appendix-a-prototype-code-full-fidelity-managed-germination.md
@@ -1,7 +1,5 @@
 ---
 title: PROTOTYPE CODE – FULL-FIDELITY MANAGED GERMINATION
-source: /home/john/esper-lite/docs/paper/draft_paper.md
-source_lines: 767-1169
 split_mode: consolidated
 appendix: "A"
 coauthors:

--- a/docs/paper/chapters/appendix-b-diagnostic-tooling-and-control.md
+++ b/docs/paper/chapters/appendix-b-diagnostic-tooling-and-control.md
@@ -1,7 +1,5 @@
 ---
 title: DIAGNOSTIC TOOLING AND CONTROL
-source: /home/john/esper-lite/docs/paper/draft_paper.md
-source_lines: 1170-1362
 split_mode: consolidated
 appendix: "B"
 coauthors:

--- a/docs/paper/chapters/appendix-c-bibliography-reading-list.md
+++ b/docs/paper/chapters/appendix-c-bibliography-reading-list.md
@@ -1,7 +1,5 @@
 ---
 title: BIBLIOGRAPHY / READING LIST
-source: /home/john/esper-lite/docs/paper/draft_paper.md
-source_lines: 1363-1401
 split_mode: consolidated
 appendix: "C"
 coauthors:


### PR DESCRIPTION
Removes file paths, source_line metadata, and tactical implementation trivia from the paper.\n\n- YAML front matter: remove source path/lines.\n- Preface: remove internal file-path references; add generic design authority note.\n- Contracts section: generalise budgets/authentication; avoid internal names.\n\nDocs only; no code.