### PR TITLE
docs: Remove MEMORY LEAK FIX marker from comment in data.py

### DIFF
--- a/src/esper/utils/data.py
+++ b/src/esper/utils/data.py
@@ -390,7 +390,7 @@ def _ensure_cifar10_cached(
         device, data_root, augment_mode=augment_mode, seed=seed
     )
 
-    # MEMORY LEAK FIX: Before creating a precompute cache entry, evict any existing
+    # Before creating a precompute cache entry, evict any existing
     # precompute entries for this device. This prevents unbounded cache growth when
     # training with different seeds (each seed would otherwise create a ~750MB entry).
     if augment_mode == "precompute" and cache_key not in _GPU_DATASET_CACHE:


### PR DESCRIPTION
Removed the temporary "MEMORY LEAK FIX" marker from the cache eviction comment in `src/esper/utils/data.py` as the fix has been fully resolved and verified. The explanatory comment describing the fix's purpose (preventing unbounded cache growth) remains intact.

---
*PR created automatically by Jules for task [15888234972542358613](https://jules.google.com/task/15888234972542358613) started by @tachyon-beep*