### PR TITLE
Remove unused ISOLATION_VIOLATION telemetry event

### DIFF
--- a/src/esper/leyline/telemetry.py
+++ b/src/esper/leyline/telemetry.py
@@ -79,9 +79,6 @@ class TelemetryEventType(Enum):
     TAMIYO_INITIATED = auto()  # Host stabilized, germination now allowed
 
     # Health events
-    # TODO: [DEAD CODE] - ISOLATION_VIOLATION is defined but never emitted or handled.
-    # Appears to be planned functionality that was never implemented. Delete or implement.
-    ISOLATION_VIOLATION = auto()
     GRADIENT_ANOMALY = auto()
     PERFORMANCE_DEGRADATION = auto()
 


### PR DESCRIPTION
Removes the dead code `ISOLATION_VIOLATION` from `TelemetryEventType` in `src/esper/leyline/telemetry.py` and its associated TODO comment.

---
*PR created automatically by Jules for task [16175867193871740201](https://jules.google.com/task/16175867193871740201) started by @tachyon-beep*