### PR TITLE
Stabilize green baseline and close initial P0 recovery bugs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,23 +1,5 @@
 {
   "enabledPlugins": {
     "code-review@claude-plugins-official": true
-  },
-  "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "filigree session-context",
-            "timeout": 5000
-          },
-          {
-            "type": "command",
-            "command": "filigree ensure-dashboard",
-            "timeout": 5000
-          }
-        ]
-      }
-    ]
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -8,12 +8,6 @@
         "-m",
         "esper.karn.mcp"
       ]
-    },
-    "filigree": {
-      "type": "stdio",
-      "command": "/home/john/.local/bin/filigree-mcp",
-      "args": [],
-      "env": {}
     }
   }
 }

--- a/docs/coord/PLAN_TRACKER.md
+++ b/docs/coord/PLAN_TRACKER.md
@@ -1,6 +1,6 @@
 # Esper Plan Tracker
 
-**Last Updated:** 2026-06-12 (green-state recovery program active)
+**Last Updated:** 2026-06-12 (baseline merged; P0 recovery active)
 **Purpose:** Rack-and-stack all plans and concepts for prioritization and dependency tracking.
 
 ---
@@ -9,13 +9,13 @@
 
 ### Green-State Recovery (2026-06-12)
 
-The project is in stabilization mode. PR #52 (`env-refactor`) is the critical
-path because it is the large unlanded baseline-reset candidate. The active plan
-is `docs/plans/ready/2026-06-12-green-state-recovery.md`.
+The project is in stabilization mode. PR #52 (`env-refactor`) was made green and
+merged into `main` as the new baseline at merge commit `cdff9c43`. The active
+plan is `docs/plans/ready/2026-06-12-green-state-recovery.md`.
 
-Current operating rule: do not land other PRs until PR #52 is either made green
-and accepted as the new baseline, or explicitly rejected with a smaller
-replacement path.
+Current operating rule: drain critical P0 correctness bugs against the merged
+baseline before starting feature work. Security/dependency PRs remain next after
+the P0 queue is stable and post-merge main CI is confirmed green.
 
 ### Post-Hiatus Audit (2026-02-21)
 
@@ -29,13 +29,14 @@ op twice independently — once in `forward()` for value computation, once in `g
 the stored action. These ops frequently diverge, corrupting advantage estimates. Blocks Phase 7.
 
 ### Current Focus Areas
-1. **Green State Recovery** - 🔴 CRITICAL! Resolve PR #52 and restore a verified mergeable baseline
-2. **Op/Value Mismatch** - 🔴 CRITICAL! Fix double-sampling in factored_lstm.py
-3. **Reward Efficiency Experiment** - Infrastructure complete, experiment never run
-4. **Phase3-TinyStories** - 85% IMPLEMENTED, needs validation runs
-5. **Drip Reward Implementation** - ~70% done, needs integration completion
-6. **Telemetry Domain Separation** - ~30% done
-7. **Blueprint Compiler** - 0% (correctly deferred until entropy confirmed stable)
+1. **Green State Recovery** - 🔴 CRITICAL! Baseline merged; drain P0 correctness bugs and confirm post-merge CI
+2. **P0 Filigree Bug Drain** - 🔴 CRITICAL! Fix silent reward, gradient, resume, and attribution corruption
+3. **Op/Value Mismatch** - 🔴 CRITICAL! Fix double-sampling in factored_lstm.py
+4. **Reward Efficiency Experiment** - Infrastructure complete, experiment never run
+5. **Phase3-TinyStories** - 85% IMPLEMENTED, needs validation runs
+6. **Drip Reward Implementation** - ~70% done, needs integration completion
+7. **Telemetry Domain Separation** - ~30% done
+8. **Blueprint Compiler** - 0% (correctly deferred until entropy confirmed stable)
 
 ### Critical Path (Updated)
 ```
@@ -64,7 +65,8 @@ the stored action. These ops frequently diverge, corrupting advantage estimates.
 
 | ID | Title | Type | Urgency | Complexity | Risk | Status |
 |----|-------|------|---------|------------|------|--------|
-| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: make PR #52 green or reject with replacement path |
+| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: PR #52 merged; post-merge CI + P0 bug drain |
+| filigree-p0-drain | Critical Filigree P0 Bug Drain | in-progress | 🔴 critical | L | high | Six P0s ready; start with reward/gradient/resume corruption |
 | op-value-mismatch | Q(s,op) Double-Sampling Bug | investigation | 🔴 critical | M | high | Diagnosed 2025-12-31, blocks Phase 7. See `docs/bugs/investigations/` |
 
 ### Tier 1: High Priority (This Week)

--- a/docs/coord/PLAN_TRACKER.md
+++ b/docs/coord/PLAN_TRACKER.md
@@ -1,6 +1,6 @@
 # Esper Plan Tracker
 
-**Last Updated:** 2026-06-12 (baseline merged; P0 recovery active)
+**Last Updated:** 2026-06-12 (baseline green; initial P0 recovery complete)
 **Purpose:** Rack-and-stack all plans and concepts for prioritization and dependency tracking.
 
 ---
@@ -10,12 +10,13 @@
 ### Green-State Recovery (2026-06-12)
 
 The project is in stabilization mode. PR #52 (`env-refactor`) was made green and
-merged into `main` as the new baseline at merge commit `cdff9c43`. The active
-plan is `docs/plans/ready/2026-06-12-green-state-recovery.md`.
+merged into `main` as the new baseline at merge commit `cdff9c43`; post-merge
+main CI passed. The active plan is
+`docs/plans/ready/2026-06-12-green-state-recovery.md`.
 
-Current operating rule: drain critical P0 correctness bugs against the merged
-baseline before starting feature work. Security/dependency PRs remain next after
-the P0 queue is stable and post-merge main CI is confirmed green.
+Current operating rule: finish broad local gates and open PR disposition before
+starting feature work. Security/dependency PRs remain next after the recovery
+branch is landed.
 
 ### Post-Hiatus Audit (2026-02-21)
 
@@ -29,8 +30,8 @@ op twice independently — once in `forward()` for value computation, once in `g
 the stored action. These ops frequently diverge, corrupting advantage estimates. Blocks Phase 7.
 
 ### Current Focus Areas
-1. **Green State Recovery** - 🔴 CRITICAL! Baseline merged; drain P0 correctness bugs and confirm post-merge CI
-2. **P0 Filigree Bug Drain** - 🔴 CRITICAL! Fix silent reward, gradient, resume, and attribution corruption
+1. **Green State Recovery** - 🔴 CRITICAL! Baseline green; recovery branch needs final gates and PR disposition
+2. **P0 Filigree Bug Drain** - ✅ Initial six P0s fixed and closed
 3. **Op/Value Mismatch** - 🔴 CRITICAL! Fix double-sampling in factored_lstm.py
 4. **Reward Efficiency Experiment** - Infrastructure complete, experiment never run
 5. **Phase3-TinyStories** - 85% IMPLEMENTED, needs validation runs
@@ -65,8 +66,8 @@ the stored action. These ops frequently diverge, corrupting advantage estimates.
 
 | ID | Title | Type | Urgency | Complexity | Risk | Status |
 |----|-------|------|---------|------------|------|--------|
-| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: PR #52 merged; post-merge CI + P0 bug drain |
-| filigree-p0-drain | Critical Filigree P0 Bug Drain | in-progress | 🔴 critical | L | high | Six P0s ready; start with reward/gradient/resume corruption |
+| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: final gates and PR disposition after green baseline + P0 fixes |
+| filigree-p0-drain | Critical Filigree P0 Bug Drain | completed-batch | 🔴 critical | L | high | Initial six P0s fixed, verified, and closed |
 | op-value-mismatch | Q(s,op) Double-Sampling Bug | investigation | 🔴 critical | M | high | Diagnosed 2025-12-31, blocks Phase 7. See `docs/bugs/investigations/` |
 
 ### Tier 1: High Priority (This Week)

--- a/docs/plans/ready/2026-06-12-green-state-recovery.md
+++ b/docs/plans/ready/2026-06-12-green-state-recovery.md
@@ -28,10 +28,10 @@ blocks:
 
 status_notes: >
   PR #52 was made green, accepted, and merged as the new baseline on 2026-06-12.
-  Main CI is running on merge commit cdff9c43. The active critical path is now
-  P0 Filigree bug drainage, starting with reward/gradient/resume correctness
-  defects that can silently corrupt learning signals.
-percent_complete: 45
+  Main CI passed on merge commit cdff9c43. The initial P0 Filigree bug drain is
+  complete for the six critical reward, gradient, resume, and attribution
+  defects identified in this recovery program.
+percent_complete: 75
 
 reviewed_by:
   - reviewer: python-engineering
@@ -64,8 +64,8 @@ Return the project to a steady state:
   - `property-tests`
   - `unit-and-integration-tests`
   - `e2e-smoke-tests`
-- Main post-merge Test Suite run: `27411344212` (pending at plan update time).
-- Filigree currently reports 50 ready issues, with six P0 bugs at the top of the queue:
+- Main post-merge Test Suite run `27411344212` passed on merge commit `cdff9c43`.
+- The six initial P0 Filigree bugs were fixed and closed:
   - `esper-lite-41841f` BASIC_PLUS drip state silently lost when `return_components=False`
   - `esper-lite-7078b7` NaN gradient norms bypass exploding detection
   - `esper-lite-52ee59` resume path loads checkpoint twice to GPU
@@ -188,7 +188,7 @@ Acceptance:
 Status:
 
 - Completed: PR #52 merged to `main` at `cdff9c43`.
-- Pending: post-merge main CI run `27411344212`.
+- Completed: post-merge main CI run `27411344212` passed.
 
 ### F. Drain Or Retarget Remaining PRs
 
@@ -223,8 +223,15 @@ Acceptance:
 - Each fixed P0 is closed in Filigree after code is committed.
 - Full repository gates are rerun after a coherent batch of P0 fixes.
 
+Status:
+
+- Completed: initial six P0 issues fixed, verified, and closed.
+- Pending: broad final repository gates and PR disposition pass.
+
 ## Execution Log
 
 - 2026-06-12: Program opened. PR #52 identified as critical path. Sidecar subagents dispatched for `origin/main` baseline verification and open PR classification.
 - 2026-06-12: PR #52 made green and merged as baseline at `cdff9c43`.
 - 2026-06-12: Recovery program moved to P0 Filigree bug drainage while post-merge main CI runs.
+- 2026-06-12: Main post-merge Test Suite `27411344212` passed.
+- 2026-06-12: Closed initial six P0 bugs: `esper-lite-41841f`, `esper-lite-7078b7`, `esper-lite-52ee59`, `esper-lite-b765c2`, `esper-lite-30e631`, and `esper-lite-102ff8`.

--- a/docs/plans/ready/2026-06-12-green-state-recovery.md
+++ b/docs/plans/ready/2026-06-12-green-state-recovery.md
@@ -10,7 +10,7 @@ updated: 2026-06-12
 owner: Codex
 
 urgency: critical
-value: Restore Esper to a mergeable, verified baseline by resolving the long-running env-refactor PR, then draining or closing stale PRs against that baseline.
+value: Restore Esper to a mergeable, verified baseline and then drain the critical correctness backlog against that baseline.
 
 complexity: M
 risk: high
@@ -27,10 +27,11 @@ blocks:
   - dependency-security-drain
 
 status_notes: >
-  Active recovery program. PR #52 is the critical path. No other PR should land
-  until #52 is either made green and accepted as the new baseline, or explicitly
-  rejected with a smaller replacement path.
-percent_complete: 20
+  PR #52 was made green, accepted, and merged as the new baseline on 2026-06-12.
+  Main CI is running on merge commit cdff9c43. The active critical path is now
+  P0 Filigree bug drainage, starting with reward/gradient/resume correctness
+  defects that can silently corrupt learning signals.
+percent_complete: 45
 
 reviewed_by:
   - reviewer: python-engineering
@@ -50,21 +51,27 @@ Return the project to a steady state:
 2. Required CI and local validation gates pass.
 3. PR #52 is either merged as the new baseline or replaced by an explicit smaller path.
 4. Remaining open PRs are classified, closed, merged, or retargeted against the selected baseline.
-5. The plan tracker and status notes reflect current reality.
+5. Critical Filigree P0 bugs that can silently corrupt training, telemetry, or resume behavior are fixed or explicitly reclassified.
+6. The plan tracker and status notes reflect current reality.
 
 ## Current Evidence
 
-- Current branch: `env-refactor`, PR #52.
-- PR #52 is the large unlanded baseline-reset candidate.
-- Previous GitHub CI for PR #52 failed in `lint` on `src/esper/simic/training/policy_group.py`.
-- Local targeted verification after the stabilization patch passed:
-  - `uv run ruff check src/ tests/`
-  - `uv run ruff check scripts/`
-  - `uv run python scripts/lint_leyline_types.py`
-  - `uv run python scripts/lint_defensive_patterns.py`
-  - `uv run python scripts/lint_gpu_sync.py`
-  - `MYPYPATH=src uv run mypy -p esper`
-  - `PYTHONPATH=src uv run pytest tests/simic -q`
+- PR #52 (`env-refactor`) was merged into `main` on 2026-06-12.
+- Merge commit: `cdff9c43847efdab65ca30faba79deade278bc1e`.
+- PR #52 verification run `27410877590` passed:
+  - `lint`
+  - `typecheck`
+  - `property-tests`
+  - `unit-and-integration-tests`
+  - `e2e-smoke-tests`
+- Main post-merge Test Suite run: `27411344212` (pending at plan update time).
+- Filigree currently reports 50 ready issues, with six P0 bugs at the top of the queue:
+  - `esper-lite-41841f` BASIC_PLUS drip state silently lost when `return_components=False`
+  - `esper-lite-7078b7` NaN gradient norms bypass exploding detection
+  - `esper-lite-52ee59` resume path loads checkpoint twice to GPU
+  - `esper-lite-b765c2` missing slot config validation on resume
+  - `esper-lite-30e631` pair attribution order mismatch
+  - `esper-lite-102ff8` FP16-scaled gradients collected before unscale
 - The working tree also contains unrelated dirty skill/config files. These must not be reverted or silently included in the PR #52 stabilization commit.
 
 ## Definition Of Green
@@ -81,12 +88,13 @@ MYPYPATH=src uv run mypy -p esper
 PYTHONPATH=src uv run pytest tests/simic -q
 ```
 
-PR #52 is remotely green only when GitHub Actions for the PR has no failing required checks. Skipped optional/nightly jobs are acceptable only if the workflow intentionally skips them for that event.
+PR #52 was remotely green when GitHub Actions for the PR had no failing required checks. Skipped optional/nightly jobs are acceptable only if the workflow intentionally skips them for that event.
 
 The project is steady only when:
 
 - `main` contains the selected baseline.
 - `main` or the merge commit has a passing required CI run.
+- Critical P0 issues are fixed, closed, or explicitly reclassified with evidence.
 - Open PRs have an explicit disposition.
 - No known task-scope defects are hidden as scratch observations.
 
@@ -177,6 +185,11 @@ Acceptance:
 - `main` has the selected baseline.
 - Required checks pass on the resulting merge or post-merge main run.
 
+Status:
+
+- Completed: PR #52 merged to `main` at `cdff9c43`.
+- Pending: post-merge main CI run `27411344212`.
+
 ### F. Drain Or Retarget Remaining PRs
 
 Owner: primary agent with subagents as needed.
@@ -192,7 +205,26 @@ Acceptance:
 - Open PR list no longer contains stale ambiguous PRs.
 - Remaining open PRs have a clear next action.
 
+### G. Drain Critical Filigree P0 Bugs
+
+Owner: primary agent with specialist subagents as needed.
+
+Scope:
+
+- Fix P0 bugs that silently corrupt reward accounting, gradient health,
+  checkpoint resume, or slot attribution.
+- Use atomic Filigree `start-work --advance` before editing.
+- Add focused regression tests for each corrected invariant.
+- Run the local gate appropriate to the touched subsystem before commit.
+
+Acceptance:
+
+- Each claimed P0 has a comment summarizing the fix and verification.
+- Each fixed P0 is closed in Filigree after code is committed.
+- Full repository gates are rerun after a coherent batch of P0 fixes.
+
 ## Execution Log
 
 - 2026-06-12: Program opened. PR #52 identified as critical path. Sidecar subagents dispatched for `origin/main` baseline verification and open PR classification.
-
+- 2026-06-12: PR #52 made green and merged as baseline at `cdff9c43`.
+- 2026-06-12: Recovery program moved to P0 Filigree bug drainage while post-merge main CI runs.

--- a/docs/plans/ready/2026-06-12-green-state-recovery.md
+++ b/docs/plans/ready/2026-06-12-green-state-recovery.md
@@ -31,7 +31,7 @@ status_notes: >
   Main CI passed on merge commit cdff9c43. The initial P0 Filigree bug drain is
   complete for the six critical reward, gradient, resume, and attribution
   defects identified in this recovery program.
-percent_complete: 75
+percent_complete: 90
 
 reviewed_by:
   - reviewer: python-engineering
@@ -205,6 +205,14 @@ Acceptance:
 - Open PR list no longer contains stale ambiguous PRs.
 - Remaining open PRs have a clear next action.
 
+Status:
+
+- Pending user action:
+  - `#71` Add Knowledge Base in `jules/` — `human-decision`; likely keep only if still desired after baseline.
+  - `#69`, `#65`, `#64` cleanup/comment PRs — `close-obsolete-after-baseline` unless still relevant after recovery branch lands.
+  - `#70` SQL injection fix — `security-priority-after-baseline`; inspect and rebase/land next.
+  - `#45`-`#63` Dependabot PRs and draft `#51` dependency consolidation — `security-priority-after-baseline` for security updates, otherwise retarget/consolidate after recovery branch.
+
 ### G. Drain Critical Filigree P0 Bugs
 
 Owner: primary agent with specialist subagents as needed.
@@ -226,7 +234,26 @@ Acceptance:
 Status:
 
 - Completed: initial six P0 issues fixed, verified, and closed.
-- Pending: broad final repository gates and PR disposition pass.
+- Completed: broad local gates passed where environment permits.
+- Blocked by local CUDA/data fetch: full `tests/simic` includes CUDA CIFAR iterator smoke files that attempted SSL dataset access and timed out locally.
+
+Final local evidence:
+
+```bash
+uv run ruff check src/ tests/
+uv run ruff check scripts/
+uv run python scripts/lint_leyline_types.py
+uv run python scripts/lint_defensive_patterns.py
+uv run python scripts/lint_gpu_sync.py
+MYPYPATH=src uv run mypy -p esper
+PYTHONPATH=src uv run pytest tests/simic --ignore=tests/simic/test_data_opt.py --ignore=tests/simic/test_record_stream_fix.py --ignore=tests/simic/training/test_dual_ab.py -q
+```
+
+The excluded files are CUDA/data-dependent smoke tests:
+
+- `tests/simic/test_data_opt.py`
+- `tests/simic/test_record_stream_fix.py`
+- `tests/simic/training/test_dual_ab.py`
 
 ## Execution Log
 
@@ -235,3 +262,4 @@ Status:
 - 2026-06-12: Recovery program moved to P0 Filigree bug drainage while post-merge main CI runs.
 - 2026-06-12: Main post-merge Test Suite `27411344212` passed.
 - 2026-06-12: Closed initial six P0 bugs: `esper-lite-41841f`, `esper-lite-7078b7`, `esper-lite-52ee59`, `esper-lite-b765c2`, `esper-lite-30e631`, and `esper-lite-102ff8`.
+- 2026-06-12: Final local gates passed except CUDA/data-dependent smoke files blocked by local SSL dataset fetch.

--- a/src/esper/simic/agent/ppo_agent.py
+++ b/src/esper/simic/agent/ppo_agent.py
@@ -1378,7 +1378,36 @@ class PPOAgent:
         Raises:
             RuntimeError: If checkpoint architecture is incompatible
         """
-        checkpoint = torch.load(path, map_location=device, weights_only=True)
+        checkpoint = torch.load(path, map_location="cpu", weights_only=True)
+        return cls.load_from_checkpoint_dict(
+            checkpoint,
+            device=device,
+            compile_mode=compile_mode,
+        )
+
+    @classmethod
+    def load_from_checkpoint_dict(
+        cls,
+        checkpoint: dict[str, Any],
+        *,
+        device: str = "cuda:0",
+        compile_mode: str | None = None,
+        expected_slot_config: SlotConfig | None = None,
+    ) -> "PPOAgent":
+        """Load agent from an already materialized checkpoint dictionary.
+
+        Args:
+            checkpoint: Checkpoint dictionary loaded on CPU.
+            device: Device to place the reconstructed agent on.
+            compile_mode: Override checkpoint's torch.compile mode.
+            expected_slot_config: Runtime slot config that must match the checkpoint.
+
+        Returns:
+            PPOAgent with restored weights and configuration.
+
+        Raises:
+            RuntimeError: If checkpoint architecture is incompatible.
+        """
 
         # Required checkpoint fields - fail fast if missing (no backwards compat)
         try:
@@ -1427,7 +1456,17 @@ class PPOAgent:
                 "Incompatible checkpoint: architecture.slot_ids is required. "
                 "Please retrain the model to create a compatible checkpoint."
             )
-        slot_config = SlotConfig(slot_ids=tuple(architecture['slot_ids']))
+        checkpoint_slot_ids = tuple(architecture['slot_ids'])
+        if (
+            expected_slot_config is not None
+            and checkpoint_slot_ids != expected_slot_config.slot_ids
+        ):
+            raise RuntimeError(
+                "Checkpoint slot_ids do not match runtime slot_ids: "
+                f"checkpoint={checkpoint_slot_ids}, "
+                f"runtime={expected_slot_config.slot_ids}"
+            )
+        slot_config = SlotConfig(slot_ids=checkpoint_slot_ids)
 
         # === Pre-load validation ===
         expected_num_slots = slot_config.num_slots

--- a/src/esper/simic/telemetry/gradient_collector.py
+++ b/src/esper/simic/telemetry/gradient_collector.py
@@ -8,6 +8,7 @@ during comparison and training loops.
 from __future__ import annotations
 
 from dataclasses import dataclass, asdict
+import math
 from typing import Iterator, TypedDict
 
 import torch
@@ -185,7 +186,9 @@ class SeedGradientCollector:
             '_total_squared_norm': total_squared_norm,
             '_all_norms': all_norms,
             '_n_vanishing': (all_norms < self.vanishing_threshold).sum(),
-            '_n_exploding': (all_norms > self.exploding_threshold).sum(),
+            '_n_exploding': (
+                (all_norms > self.exploding_threshold) | ~torch.isfinite(all_norms)
+            ).sum(),
         }
 
 
@@ -230,15 +233,19 @@ def materialize_grad_stats(async_stats: dict[str, bool | int | float | torch.Ten
     # NOTE: Previous code divided by n_grads, producing values incomparable to
     # clipping thresholds. Global L2 = sqrt(sum(||g_i||²)) without division.
     gradient_norm = total_squared_norm ** 0.5
+    norm_is_finite = math.isfinite(gradient_norm)
 
     # Compute health score (0-1, higher is healthier)
     vanishing_ratio = n_vanishing / n_grads
     exploding_ratio = n_exploding / n_grads
 
-    health = 1.0
-    health -= vanishing_ratio * 0.5  # Penalize vanishing
-    health -= exploding_ratio * 0.8  # Penalize exploding more
-    health = max(0.0, min(1.0, health))
+    if norm_is_finite:
+        health = 1.0
+        health -= vanishing_ratio * 0.5  # Penalize vanishing
+        health -= exploding_ratio * 0.8  # Penalize exploding more
+        health = max(0.0, min(1.0, health))
+    else:
+        health = 0.0
 
     return {
         'gradient_norm': gradient_norm,
@@ -309,7 +316,9 @@ def collect_seed_gradients(
     min_norm_t = all_norms.min()
     max_norm_t = all_norms.max()
     n_vanishing_t = (all_norms < vanishing_threshold).sum()
-    n_exploding_t = (all_norms > exploding_threshold).sum()
+    n_exploding_t = (
+        (all_norms > exploding_threshold) | ~torch.isfinite(all_norms)
+    ).sum()
 
     # C6 FIX: Vectorized quality checks to avoid torch.compile graph breaks.
     # Trade-off: allocates O(total_params) temporary tensor, but eliminates
@@ -344,6 +353,7 @@ def collect_seed_gradients(
     # NOTE: Previous code divided by n_grads, producing values incomparable to
     # clipping thresholds. Global L2 = sqrt(sum(||g_i||²)) without division.
     gradient_norm = total_squared_val ** 0.5
+    norm_is_finite = math.isfinite(gradient_norm)
     n_vanishing = int(n_vanishing)
     n_exploding = int(n_exploding)
     zero_fraction = zero_count / max(total_elements, 1)
@@ -356,10 +366,13 @@ def collect_seed_gradients(
     # Health score
     vanishing_ratio = n_vanishing / n_grads
     exploding_ratio = n_exploding / n_grads
-    health = 1.0
-    health -= vanishing_ratio * 0.5
-    health -= exploding_ratio * 0.8
-    health = max(0.0, min(1.0, health))
+    if norm_is_finite:
+        health = 1.0
+        health -= vanishing_ratio * 0.5
+        health -= exploding_ratio * 0.8
+        health = max(0.0, min(1.0, health))
+    else:
+        health = 0.0
 
     if return_enhanced:
         return GradientHealthMetrics(

--- a/src/esper/simic/training/action_execution.py
+++ b/src/esper/simic/training/action_execution.py
@@ -94,6 +94,11 @@ _HEAD_OP_IDX = _HEAD_NAME_TO_IDX["op"]
 _logger = logging.getLogger(__name__)
 
 
+def _reward_components_required_for_state_transport(reward_mode: RewardMode) -> bool:
+    """Reward modes that persist state via RewardComponentsTelemetry."""
+    return reward_mode in (RewardMode.ESCROW, RewardMode.BASIC_PLUS)
+
+
 class ResolveTargetSlot(Protocol):
     def __call__(
         self,
@@ -511,8 +516,8 @@ def execute_actions(
                 else None
             )
             seed_id = seed_state.seed_id if seed_state is not None else None
-            force_reward_components = (
-                env_reward_configs[env_idx].reward_mode == RewardMode.ESCROW
+            force_reward_components = _reward_components_required_for_state_transport(
+                env_reward_configs[env_idx].reward_mode
             )
             return_components = (
                 emit_reward_components_event
@@ -575,7 +580,10 @@ def execute_actions(
                     reward_components.host_baseline_acc = baseline_accs[env_idx][
                         target_slot
                     ]
-                if force_reward_components and reward_components is not None:
+                if (
+                    env_reward_configs[env_idx].reward_mode == RewardMode.ESCROW
+                    and reward_components is not None
+                ):
                     env_state.escrow_credit[target_slot] = (
                         reward_components.escrow_credit_next
                     )

--- a/src/esper/simic/training/batch_ops.py
+++ b/src/esper/simic/training/batch_ops.py
@@ -200,12 +200,6 @@ def process_train_batch(
             env_state.scaler.scale(loss).backward()  # type: ignore[no-untyped-call]
         else:
             loss.backward()  # type: ignore[no-untyped-call]
-        # Collect gradient telemetry (isolated from torch.compile)
-        grad_stats_by_slot = None
-        if use_telemetry:
-            grad_stats_by_slot = _collect_gradient_telemetry_for_batch(
-                model, slots_with_active_seeds, env_dev
-            )
 
         # Compute grad presence once for each seed optimizer (avoid redundant checks)
         # Guard: Only call scaler.step() if optimizer has gradients.
@@ -220,10 +214,28 @@ def process_train_batch(
             )
             seed_opts_with_grads[slot_id] = (seed_opt, has_grads)
 
+        clipping_enabled = max_grad_norm is not None and max_grad_norm > 0
+        grads_unscaled = False
+        if env_state.scaler is not None and (use_telemetry or clipping_enabled):
+            env_state.scaler.unscale_(env_state.host_optimizer)
+            for slot_id, (seed_opt, has_grads) in seed_opts_with_grads.items():
+                if has_grads:
+                    env_state.scaler.unscale_(seed_opt)
+            grads_unscaled = True
+
+        # Collect gradient telemetry (isolated from torch.compile).
+        # FP16 GradScaler stores scaled grads after backward; collect only after unscale.
+        grad_stats_by_slot = None
+        if use_telemetry:
+            grad_stats_by_slot = _collect_gradient_telemetry_for_batch(
+                model, slots_with_active_seeds, env_dev
+            )
+
         # Gradient clipping (AMP-safe)
         # AMP ordering: scale() -> backward() -> unscale_() -> clip_grad_norm_() -> step() -> update()
-        if max_grad_norm is not None and max_grad_norm > 0:
-            if env_state.scaler is not None:
+        if clipping_enabled:
+            assert max_grad_norm is not None
+            if env_state.scaler is not None and not grads_unscaled:
                 # Unscale before clipping (required for correct FP32 magnitude)
                 env_state.scaler.unscale_(env_state.host_optimizer)
                 for slot_id, (seed_opt, has_grads) in seed_opts_with_grads.items():

--- a/src/esper/simic/training/vectorized.py
+++ b/src/esper/simic/training/vectorized.py
@@ -804,8 +804,12 @@ def train_ppo_vectorized(
 
     # Create or resume PPO agent
     if resume_path:
-        checkpoint = torch.load(resume_path, map_location=device, weights_only=True)
-        agent = PPOAgent.load(resume_path, device=device)
+        checkpoint = torch.load(resume_path, map_location="cpu", weights_only=True)
+        agent = PPOAgent.load_from_checkpoint_dict(
+            checkpoint,
+            device=device,
+            expected_slot_config=slot_config,
+        )
 
         # Restore observation normalizer state
         metadata = checkpoint["metadata"]

--- a/src/esper/simic/training/vectorized_trainer.py
+++ b/src/esper/simic/training/vectorized_trainer.py
@@ -48,6 +48,27 @@ from esper.simic.vectorized_types import (
 )
 
 
+def _pair_slot_key(
+    active_slot_list: list[str],
+    pair_indices: tuple[int, int],
+) -> tuple[str, str]:
+    """Convert pair config indices into stable slot IDs at encode time."""
+    idx_i, idx_j = pair_indices
+    return active_slot_list[idx_i], active_slot_list[idx_j]
+
+
+def _pair_index_accs_for_active_slots(
+    pair_accs_by_slot: dict[tuple[str, str], float],
+    active_slots: list[str],
+) -> dict[tuple[int, int], float]:
+    """Convert slot-keyed pair accuracies to emitter index keys."""
+    slot_to_index = {slot_id: idx for idx, slot_id in enumerate(active_slots)}
+    return {
+        (slot_to_index[slot_a], slot_to_index[slot_b]): pair_acc
+        for (slot_a, slot_b), pair_acc in pair_accs_by_slot.items()
+    }
+
+
 @dataclass
 class VectorizedPPOTrainer:
     agent: Any
@@ -638,7 +659,10 @@ class VectorizedPPOTrainer:
                                             if k != idx_i and k != idx_j
                                         }
                                         pair_config["_kind"] = "pair"
-                                        pair_config["_pair"] = (idx_i, idx_j)
+                                        pair_config["_pair"] = _pair_slot_key(
+                                            active_slot_list,
+                                            (idx_i, idx_j),
+                                        )
                                         configs.append(pair_config)
 
                             # Committed accuracy: only fossilized seeds enabled.
@@ -694,7 +718,7 @@ class VectorizedPPOTrainer:
                         {} for _ in range(envs_this_batch)
                     ]
                     all_disabled_accs: dict[int, float] = {}
-                    pair_accs: dict[int, dict[tuple[int, int], float]] = {}
+                    pair_accs: dict[int, dict[tuple[str, str], float]] = {}
                     shapley_results: dict[
                         int, dict[tuple[bool, ...], tuple[float, float]]
                     ] = {}
@@ -955,6 +979,14 @@ class VectorizedPPOTrainer:
                         # Lexicographic sort on slot IDs ensures correct upstream/downstream alpha sums.
                         active_slots = sorted(baseline_accs[i].keys())
                         if active_slots:
+                            pair_accs_for_emitter = (
+                                _pair_index_accs_for_active_slots(
+                                    pair_accs[i],
+                                    active_slots,
+                                )
+                                if i in pair_accs
+                                else {}
+                            )
                             emitters[i].on_counterfactual_matrix(
                                 active_slots=active_slots,
                                 baseline_accs=baseline_accs[i],
@@ -962,7 +994,7 @@ class VectorizedPPOTrainer:
                                 all_disabled_acc=all_disabled_accs.get(
                                     i
                                 ),  # None triggers emitter fallback
-                                pair_accs=pair_accs.get(i, {}),
+                                pair_accs=pair_accs_for_emitter,
                                 solo_accs=solo_on_accs[i],
                             )
 
@@ -973,10 +1005,7 @@ class VectorizedPPOTrainer:
                             all_off_acc = all_disabled_accs.get(i)
                             if all_off_acc is None:
                                 all_off_acc = min(baseline_accs[i].values())
-                            for (idx_a, idx_b), pair_acc in pair_accs[i].items():
-                                # Map indices to slot IDs
-                                slot_a = active_slots[idx_a]
-                                slot_b = active_slots[idx_b]
+                            for (slot_a, slot_b), pair_acc in pair_accs[i].items():
                                 # Solo accuracies MUST exist - active_slots derived from baseline_accs keys
                                 solo_a = baseline_accs[i][slot_a]
                                 solo_b = baseline_accs[i][slot_b]

--- a/tests/simic/test_gradient_collector.py
+++ b/tests/simic/test_gradient_collector.py
@@ -1,5 +1,7 @@
 """Tests for gradient collector performance and correctness."""
 
+import math
+
 import torch
 import torch.nn as nn
 import pytest
@@ -172,6 +174,19 @@ class TestSeedGradientCollectorEdgeCases:
         assert stats["has_exploding"] is True
         assert stats["gradient_health"] < 1.0
 
+    def test_nan_gradient_norm_counts_as_exploding_and_unhealthy(self):
+        """NaN gradients must trip exploding detection and zero health."""
+        param = torch.nn.Parameter(torch.ones(2, 2))
+        param.grad = torch.tensor([[1.0, float("nan")], [2.0, 3.0]])
+
+        collector = SeedGradientCollector()
+        stats = collector.collect([param])
+
+        assert math.isnan(stats["gradient_norm"])
+        assert stats["has_exploding"] is True
+        assert stats["has_vanishing"] is False
+        assert stats["gradient_health"] == 0.0
+
     def test_gradient_health_scoring_orders(self):
         """Healthy gradients score higher than mixed vanishing+exploding."""
         collector = SeedGradientCollector()
@@ -277,6 +292,23 @@ class TestEnhancedCollector:
         assert result.gradient_norm > 0
         assert result.min_layer_norm > 0
         assert result.max_layer_norm >= result.min_layer_norm
+
+    def test_collect_seed_gradients_nan_counts_as_exploding_and_unhealthy(self):
+        """Convenience collector agrees with SeedGradientCollector on NaN safety."""
+        param = torch.nn.Parameter(torch.ones(2, 2))
+        param.grad = torch.tensor([[1.0, float("nan")], [2.0, 3.0]])
+
+        basic = collect_seed_gradients([param])
+        enhanced = collect_seed_gradients([param], return_enhanced=True)
+
+        assert math.isnan(basic["gradient_norm"])
+        assert basic["has_exploding"] is True
+        assert basic["gradient_health"] == 0.0
+        assert isinstance(enhanced, GradientHealthMetrics)
+        assert math.isnan(enhanced.gradient_norm)
+        assert enhanced.has_exploding is True
+        assert enhanced.gradient_health == 0.0
+        assert enhanced.nan_count == 1
 
 
 # =============================================================================

--- a/tests/simic/test_ppo_checkpoint.py
+++ b/tests/simic/test_ppo_checkpoint.py
@@ -137,6 +137,41 @@ class TestPPOCheckpointValidation:
         with pytest.raises(RuntimeError, match="architecture.slot_ids is required"):
             PPOAgent.load(tmp_path / "corrupted.pt", device="cpu")
 
+    def test_load_from_checkpoint_dict_rejects_expected_slot_id_mismatch_before_policy_creation(
+        self,
+        monkeypatch,
+    ):
+        """Runtime slot IDs must match checkpoint slot IDs before policy creation."""
+        import esper.tamiyo.policy.factory as policy_factory
+
+        def fail_create_policy(*args, **kwargs):
+            raise AssertionError("slot mismatch should fail before policy creation")
+
+        monkeypatch.setattr(policy_factory, "create_policy", fail_create_policy)
+
+        checkpoint = {
+            "checkpoint_version": CHECKPOINT_VERSION,
+            "network_state_dict": {},
+            "optimizer_state_dict": {},
+            "value_normalizer_state_dict": {},
+            "train_steps": 0,
+            "aux_training_step": 0,
+            "config": {
+                "compile_mode": "off",
+            },
+            "architecture": {
+                "slot_ids": ("r0c0",),
+                "state_dim": 1,
+            },
+        }
+
+        with pytest.raises(RuntimeError, match="checkpoint=.*r0c0.*runtime=.*r0c1"):
+            PPOAgent.load_from_checkpoint_dict(
+                checkpoint,
+                device="cpu",
+                expected_slot_config=SlotConfig(slot_ids=("r0c1",)),
+            )
+
 
 class TestPPOCheckpointNoBackwardsCompatibility:
     """Verify legacy checkpoints are rejected (No Legacy Code Policy)."""

--- a/tests/simic/test_reward_modes.py
+++ b/tests/simic/test_reward_modes.py
@@ -649,3 +649,54 @@ def test_basic_plus_mode_creates_drip_state() -> None:
     assert new_drip_state.drip_total > 0
     # Immediate bonus should be 30% of full bonus (drip_fraction=0.7)
     assert fossilize_bonus > 0
+
+
+def test_basic_plus_action_execution_requests_components_for_drip_transport() -> None:
+    """BASIC_PLUS must request components even without telemetry collection."""
+    from esper.leyline import LifecycleOp, SeedStage
+    from esper.simic.rewards.contribution import ContributionRewardConfig, RewardMode
+    from esper.simic.rewards.rewards import compute_reward
+    from esper.simic.rewards.types import ContributionRewardInputs, SeedInfo
+    from esper.simic.training.action_execution import (
+        _reward_components_required_for_state_transport,
+    )
+
+    config = ContributionRewardConfig(reward_mode=RewardMode.BASIC_PLUS)
+    return_components = (
+        False
+        or False
+        or _reward_components_required_for_state_transport(config.reward_mode)
+    )
+
+    inputs = ContributionRewardInputs(
+        action=LifecycleOp.FOSSILIZE,
+        seed_contribution=5.0,
+        val_acc=0.85,
+        seed_info=SeedInfo(
+            stage=SeedStage.HOLDING.value,
+            improvement_since_stage_start=0.5,
+            total_improvement=5.0,
+            epochs_in_stage=5,
+            seed_params=10_000,
+            previous_stage=SeedStage.BLENDING.value,
+            previous_epochs_in_stage=3,
+            seed_age_epochs=20,
+        ),
+        epoch=20,
+        max_epochs=150,
+        total_params=110_000,
+        host_params=100_000,
+        acc_at_germination=0.70,
+        acc_delta=5.0,
+        config=config,
+        return_components=return_components,
+        seed_id="test-seed",
+        slot_id="r0c1",
+    )
+
+    reward, components = compute_reward(inputs)
+
+    assert reward > 0
+    assert components.new_drip_state is not None
+    assert components.new_drip_state.seed_id == "test-seed"
+    assert components.new_drip_state.slot_id == "r0c1"

--- a/tests/simic/test_reward_normalizer_checkpoint.py
+++ b/tests/simic/test_reward_normalizer_checkpoint.py
@@ -157,7 +157,11 @@ def test_resume_restores_reward_normalizer_state(monkeypatch, tmp_path):
     monkeypatch.setattr(vectorized, "get_hub", lambda: StubHub())
     monkeypatch.setattr(vectorized, "RewardNormalizer", StubRewardNormalizer)
     monkeypatch.setattr(vectorized, "SharedBatchIterator", StubSharedBatchIterator)
-    monkeypatch.setattr(vectorized.PPOAgent, "load", lambda *args, **kwargs: object())
+    monkeypatch.setattr(
+        vectorized.PPOAgent,
+        "load_from_checkpoint_dict",
+        lambda *args, **kwargs: object(),
+    )
 
     checkpoint_path = tmp_path / "checkpoint.pt"
     torch.save(
@@ -196,3 +200,127 @@ def test_resume_restores_reward_normalizer_state(monkeypatch, tmp_path):
     assert reward_normalizer.mean == 1.23
     assert reward_normalizer.m2 == 4.56
     assert reward_normalizer.count == 7
+
+
+def test_resume_uses_single_preloaded_checkpoint_for_agent_and_metadata(
+    monkeypatch, tmp_path
+):
+    import esper.runtime as runtime
+    import esper.simic.training.vectorized as vectorized
+    from esper.leyline import TelemetryEventType
+
+    original_get_task_spec = runtime.get_task_spec
+    original_torch_load = torch.load
+    load_calls = []
+
+    def get_task_spec_mock(name: str):
+        spec = original_get_task_spec(name)
+        spec.dataloader_defaults["mock"] = True
+        return spec
+
+    def torch_load_mock(*args, **kwargs):
+        load_calls.append((args, kwargs))
+        return original_torch_load(*args, **kwargs)
+
+    class StubHub:
+        def add_backend(self, _backend) -> None:
+            return None
+
+        def emit(self, event) -> None:
+            if event.event_type == TelemetryEventType.CHECKPOINT_LOADED:
+                raise _StopAfterCheckpointLoaded()
+            return None
+
+    class StubSharedBatchIterator:
+        def __init__(self, *args, **kwargs):
+            return None
+
+        def __len__(self) -> int:
+            return 0
+
+    monkeypatch.setattr(runtime, "get_task_spec", get_task_spec_mock)
+    monkeypatch.setattr(vectorized, "get_hub", lambda: StubHub())
+    monkeypatch.setattr(vectorized, "SharedBatchIterator", StubSharedBatchIterator)
+    monkeypatch.setattr(vectorized.torch, "load", torch_load_mock)
+    monkeypatch.setattr(
+        vectorized.PPOAgent,
+        "load_from_checkpoint_dict",
+        lambda *args, **kwargs: object(),
+    )
+
+    checkpoint_path = tmp_path / "checkpoint.pt"
+    torch.save(
+        {
+            "metadata": {
+                "n_episodes": 0,
+                "batches_completed": 0,
+                "n_envs": 1,
+            }
+        },
+        checkpoint_path,
+    )
+
+    with pytest.raises(_StopAfterCheckpointLoaded):
+        vectorized.train_ppo_vectorized(
+            n_episodes=1,
+            n_envs=1,
+            max_epochs=1,
+            chunk_length=1,
+            device="cpu",
+            devices=["cpu"],
+            task="cifar_baseline",
+            slots=["r0c1"],
+            use_telemetry=False,
+            num_workers=0,
+            resume_path=str(checkpoint_path),
+            quiet_analytics=True,
+        )
+
+    assert len(load_calls) == 1
+    assert load_calls[0][0][0] == str(checkpoint_path)
+    assert load_calls[0][1]["map_location"] == "cpu"
+
+
+def test_resume_rejects_checkpoint_slot_ids_that_do_not_match_runtime_slots(
+    tmp_path,
+):
+    import esper.simic.training.vectorized as vectorized
+    from esper.leyline.slot_config import SlotConfig
+    from esper.simic.agent import PPOAgent
+    from esper.tamiyo.policy.factory import create_policy
+    from esper.tamiyo.policy.features import get_feature_size
+
+    checkpoint_slot_config = SlotConfig(slot_ids=("r0c0",))
+    policy = create_policy(
+        policy_type="lstm",
+        state_dim=get_feature_size(checkpoint_slot_config),
+        slot_config=checkpoint_slot_config,
+        device="cpu",
+        compile_mode="off",
+    )
+    agent = PPOAgent(policy=policy, slot_config=checkpoint_slot_config, device="cpu")
+    checkpoint_path = tmp_path / "checkpoint.pt"
+    agent.save(
+        checkpoint_path,
+        metadata={
+            "n_episodes": 0,
+            "batches_completed": 0,
+            "n_envs": 1,
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="checkpoint=.*r0c0.*runtime=.*r0c1"):
+        vectorized.train_ppo_vectorized(
+            n_episodes=1,
+            n_envs=1,
+            max_epochs=1,
+            chunk_length=1,
+            device="cpu",
+            devices=["cpu"],
+            task="cifar_baseline",
+            slots=["r0c1"],
+            use_telemetry=False,
+            num_workers=0,
+            resume_path=str(checkpoint_path),
+            quiet_analytics=True,
+        )

--- a/tests/simic/test_vectorized.py
+++ b/tests/simic/test_vectorized.py
@@ -23,6 +23,10 @@ from esper.simic.training.vectorized import (
     _resolve_target_slot,
     _run_ppo_updates,
 )
+from esper.simic.training.vectorized_trainer import (
+    _pair_index_accs_for_active_slots,
+    _pair_slot_key,
+)
 from esper.simic.telemetry.emitters import (
     apply_slot_telemetry,
     check_performance_degradation,
@@ -40,6 +44,22 @@ from esper.simic.telemetry.emitters import (
 # =============================================================================
 # Telemetry Emission Tests
 # =============================================================================
+
+
+def test_pair_attribution_keys_survive_non_lexicographic_slot_order():
+    """Pair attribution stores slot IDs before any sorted decoding occurs."""
+    user_slot_order = ["r0c2", "r0c0", "r0c1"]
+    pair_key = _pair_slot_key(user_slot_order, (0, 2))
+
+    assert pair_key == ("r0c2", "r0c1")
+
+    sorted_active_slots = sorted(user_slot_order)
+    emitter_pair_accs = _pair_index_accs_for_active_slots(
+        {pair_key: 47.0},
+        sorted_active_slots,
+    )
+
+    assert emitter_pair_accs == {(2, 1): 47.0}
 
 
 def test_lifecycle_only_keeps_slot_telemetry():

--- a/tests/simic/training/test_gradient_clipping.py
+++ b/tests/simic/training/test_gradient_clipping.py
@@ -4,10 +4,20 @@ These tests verify that gradient clipping is correctly implemented with proper
 AMP-safe ordering (unscale_ before clip_grad_norm_).
 """
 
+from dataclasses import dataclass
+from typing import Iterator
+from unittest.mock import MagicMock
+
+import pytest
 import torch
 import torch.nn as nn
-from unittest.mock import MagicMock
-from typing import Iterator
+
+from esper.leyline import SeedStage
+from esper.simic.telemetry.gradient_collector import (
+    DEFAULT_EXPLODING_THRESHOLD,
+    materialize_grad_stats,
+)
+from esper.simic.training.batch_ops import process_train_batch
 
 
 class MockSlottedModel(nn.Module):
@@ -31,6 +41,67 @@ class MockSlottedModel(nn.Module):
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         return self.host_linear(x) + self.seed_linear(x)
+
+
+@dataclass
+class _TaskSpec:
+    seed_lr: float = 0.01
+    task_type: str = "classification"
+
+
+class _FakeScaler:
+    def __init__(self, scale_factor: float):
+        self.scale_factor = scale_factor
+        self.unscale_calls = 0
+        self.step_calls = 0
+        self.update_calls = 0
+
+    def scale(self, loss: torch.Tensor) -> torch.Tensor:
+        return loss * self.scale_factor
+
+    def unscale_(self, optimizer: torch.optim.Optimizer) -> None:
+        self.unscale_calls += 1
+        for group in optimizer.param_groups:
+            for param in group["params"]:
+                if param.grad is not None:
+                    param.grad.div_(self.scale_factor)
+
+    def step(self, optimizer: torch.optim.Optimizer) -> None:
+        self.step_calls += 1
+        optimizer.step()
+
+    def update(self) -> None:
+        self.update_calls += 1
+
+
+def _loss_and_correct(
+    outputs: torch.Tensor,
+    targets: torch.Tensor,
+    criterion: nn.Module,
+    *,
+    task_type: str,
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    loss = criterion(outputs, targets)
+    correct = torch.tensor(0, device=outputs.device)
+    return loss, correct, int(targets.shape[0])
+
+
+def _make_env_state_with_scaler(
+    model: MockSlottedModel,
+    scaler: _FakeScaler,
+) -> MagicMock:
+    slot = MagicMock()
+    slot.state = MagicMock(stage=SeedStage.TRAINING)
+    model.seed_slots["r0c1"] = slot
+    env_state = MagicMock()
+    env_state.model = model
+    env_state.env_device = "cpu"
+    env_state.stream = None
+    env_state.autocast_enabled = False
+    env_state.scaler = scaler
+    env_state.host_optimizer = torch.optim.SGD(model.host_linear.parameters(), lr=0.01)
+    env_state.seed_optimizers = {}
+    return env_state
 
 
 class TestGradientClippingAMPOrdering:
@@ -74,6 +145,39 @@ class TestGradientClippingAMPOrdering:
         unscale_idx = next(i for i, c in enumerate(call_order) if c.startswith("unscale_"))
         clip_idx = call_order.index("clip_grad_norm_")
         assert unscale_idx < clip_idx, "unscale_() must be called before clip_grad_norm_()"
+
+    @pytest.mark.parametrize("max_grad_norm", [0.5, None])
+    def test_process_train_batch_collects_unscaled_amp_telemetry(
+        self,
+        max_grad_norm: float | None,
+    ):
+        """AMP telemetry uses unscaled gradients before optional clipping."""
+        torch.manual_seed(0)
+        model = MockSlottedModel()
+        scaler = _FakeScaler(scale_factor=1024.0)
+        env_state = _make_env_state_with_scaler(model, scaler)
+        criterion = nn.MSELoss()
+        inputs = torch.randn(4, 10)
+        targets = torch.zeros(4, 10)
+
+        _, _, _, grad_stats = process_train_batch(
+            env_state,
+            inputs,
+            targets,
+            criterion,
+            use_telemetry=True,
+            slots=["r0c1"],
+            max_grad_norm=max_grad_norm,
+            task_spec=_TaskSpec(),
+            resolved_amp_dtype=None,
+            loss_and_correct_fn=_loss_and_correct,
+        )
+
+        assert grad_stats is not None
+        health_stats = materialize_grad_stats(grad_stats["r0c1"]["_health_stats"])
+        assert health_stats["gradient_norm"] < DEFAULT_EXPLODING_THRESHOLD
+        assert health_stats["has_exploding"] is False
+        assert scaler.unscale_calls == 2
 
     def test_clip_grad_norm_actually_clips_large_gradients(self):
         """Verify that clip_grad_norm_ actually limits gradient magnitude."""


### PR DESCRIPTION
## Summary
- stabilizes the post-PR baseline with six P0 Simic recovery fixes
- removes the project-level Filigree MCP/hooks install entries from tracked config
- records recovery verification evidence and follow-up PR disposition in the coordination docs

## Fixed P0s
- preserve BASIC_PLUS/ESCROW drip state when reward components are not returned to callers
- treat non-finite gradient norms as unhealthy/exploding while preserving telemetry values
- load PPO resume checkpoints once on CPU and validate slot config before construction
- keep pair-attribution internal state keyed by slot id instead of sorted slot indices
- unscale AMP gradients before telemetry and clipping

## Verification
- `PYTHONPATH=src uv run pytest tests/simic/test_reward_modes.py tests/simic/test_gradient_collector.py tests/simic/telemetry/test_gradient_collector_overflow.py tests/simic/test_reward_normalizer_checkpoint.py tests/simic/test_ppo_checkpoint.py tests/simic/test_vectorized.py tests/simic/training/test_gradient_clipping.py -q`
- `uv run ruff check src/ tests/`
- `uv run ruff check scripts/`
- `uv run python scripts/lint_leyline_types.py`
- `uv run python scripts/lint_defensive_patterns.py`
- `uv run python scripts/lint_gpu_sync.py`
- `MYPYPATH=src uv run mypy -p esper`
- `PYTHONPATH=src uv run pytest tests/simic --ignore=tests/simic/test_data_opt.py --ignore=tests/simic/test_record_stream_fix.py --ignore=tests/simic/training/test_dual_ab.py -q`

## Notes
- Full local Simic sweep was blocked by CUDA/data-fetch smoke tests in `tests/simic/test_data_opt.py`, `tests/simic/test_record_stream_fix.py`, and `tests/simic/training/test_dual_ab.py`; the non-CUDA/data-fetch Simic sweep passed.
- Main is already green after PR #52 merge; this branch is the first recovery batch on top of that baseline.
