### PR TITLE
Harden PPO stability telemetry and KL accounting

### DIFF
--- a/docs/coord/PLAN_TRACKER.md
+++ b/docs/coord/PLAN_TRACKER.md
@@ -1,6 +1,6 @@
 # Esper Plan Tracker
 
-**Last Updated:** 2026-06-12 (baseline green; initial P0 recovery complete)
+**Last Updated:** 2026-06-12 (baseline green; P1 stability batch 1 active)
 **Purpose:** Rack-and-stack all plans and concepts for prioritization and dependency tracking.
 
 ---
@@ -14,9 +14,11 @@ merged into `main` as the new baseline at merge commit `cdff9c43`; post-merge
 main CI passed. The active plan is
 `docs/plans/ready/2026-06-12-green-state-recovery.md`.
 
-Current operating rule: finish broad local gates and open PR disposition before
-starting feature work. Security/dependency PRs remain next after the recovery
-branch is landed.
+Current operating rule: drain high-risk correctness bugs before feature work.
+Recovery PR #72 is merged. The active follow-up is
+`docs/plans/ready/2026-06-12-p1-stability-batch-1.md`.
+Security/dependency PRs remain next after the first P1 stability batch unless a
+fresh critical correctness bug appears.
 
 ### Post-Hiatus Audit (2026-02-21)
 
@@ -30,14 +32,15 @@ op twice independently — once in `forward()` for value computation, once in `g
 the stored action. These ops frequently diverge, corrupting advantage estimates. Blocks Phase 7.
 
 ### Current Focus Areas
-1. **Green State Recovery** - 🔴 CRITICAL! Baseline green; recovery branch needs final gates and PR disposition
-2. **P0 Filigree Bug Drain** - ✅ Initial six P0s fixed and closed
-3. **Op/Value Mismatch** - 🔴 CRITICAL! Fix double-sampling in factored_lstm.py
-4. **Reward Efficiency Experiment** - Infrastructure complete, experiment never run
-5. **Phase3-TinyStories** - 85% IMPLEMENTED, needs validation runs
-6. **Drip Reward Implementation** - ~70% done, needs integration completion
-7. **Telemetry Domain Separation** - ~30% done
-8. **Blueprint Compiler** - 0% (correctly deferred until entropy confirmed stable)
+1. **Green State Recovery** - 🔴 CRITICAL! Baseline green; post-baseline P1 stability drain active
+2. **P1 Stability Batch 1** - 🔴 CRITICAL! Six high-risk PPO/telemetry correctness bugs claimed
+3. **P0 Filigree Bug Drain** - ✅ Initial six P0s fixed and closed
+4. **Op/Value Mismatch** - 🔴 CRITICAL! Fix double-sampling in factored_lstm.py
+5. **Reward Efficiency Experiment** - Infrastructure complete, experiment never run
+6. **Phase3-TinyStories** - 85% IMPLEMENTED, needs validation runs
+7. **Drip Reward Implementation** - ~70% done, needs integration completion
+8. **Telemetry Domain Separation** - ~30% done
+9. **Blueprint Compiler** - 0% (correctly deferred until entropy confirmed stable)
 
 ### Critical Path (Updated)
 ```
@@ -67,6 +70,7 @@ the stored action. These ops frequently diverge, corrupting advantage estimates.
 | ID | Title | Type | Urgency | Complexity | Risk | Status |
 |----|-------|------|---------|------------|------|--------|
 | green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: final gates and PR disposition after green baseline + P0 fixes |
+| p1-stability-batch-1 | PPO/Telemetry Stability Batch 1 | in-progress | 🔴 critical | M | high | Active: entropy/KL accounting, rollout_total_steps, non-finite gradient drift |
 | filigree-p0-drain | Critical Filigree P0 Bug Drain | completed-batch | 🔴 critical | L | high | Initial six P0s fixed, verified, and closed |
 | op-value-mismatch | Q(s,op) Double-Sampling Bug | investigation | 🔴 critical | M | high | Diagnosed 2025-12-31, blocks Phase 7. See `docs/bugs/investigations/` |
 

--- a/docs/coord/PLAN_TRACKER.md
+++ b/docs/coord/PLAN_TRACKER.md
@@ -1,6 +1,6 @@
 # Esper Plan Tracker
 
-**Last Updated:** 2026-06-12 (baseline green; P1 stability batch 1 active)
+**Last Updated:** 2026-06-12 (baseline green; P1 stability batch 1 locally complete)
 **Purpose:** Rack-and-stack all plans and concepts for prioritization and dependency tracking.
 
 ---
@@ -15,10 +15,9 @@ main CI passed. The active plan is
 `docs/plans/ready/2026-06-12-green-state-recovery.md`.
 
 Current operating rule: drain high-risk correctness bugs before feature work.
-Recovery PR #72 is merged. The active follow-up is
-`docs/plans/ready/2026-06-12-p1-stability-batch-1.md`.
-Security/dependency PRs remain next after the first P1 stability batch unless a
-fresh critical correctness bug appears.
+Recovery PR #72 is merged. P1 stability batch 1 is locally complete and ready
+for PR verification. Security/dependency PRs remain next unless a fresh critical
+correctness bug appears.
 
 ### Post-Hiatus Audit (2026-02-21)
 
@@ -33,7 +32,7 @@ the stored action. These ops frequently diverge, corrupting advantage estimates.
 
 ### Current Focus Areas
 1. **Green State Recovery** - 🔴 CRITICAL! Baseline green; post-baseline P1 stability drain active
-2. **P1 Stability Batch 1** - 🔴 CRITICAL! Six high-risk PPO/telemetry correctness bugs claimed
+2. **P1 Stability Batch 1** - ✅ Locally complete; six high-risk PPO/telemetry correctness bugs closed
 3. **P0 Filigree Bug Drain** - ✅ Initial six P0s fixed and closed
 4. **Op/Value Mismatch** - 🔴 CRITICAL! Fix double-sampling in factored_lstm.py
 5. **Reward Efficiency Experiment** - Infrastructure complete, experiment never run
@@ -70,7 +69,7 @@ the stored action. These ops frequently diverge, corrupting advantage estimates.
 | ID | Title | Type | Urgency | Complexity | Risk | Status |
 |----|-------|------|---------|------------|------|--------|
 | green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: final gates and PR disposition after green baseline + P0 fixes |
-| p1-stability-batch-1 | PPO/Telemetry Stability Batch 1 | in-progress | 🔴 critical | M | high | Active: entropy/KL accounting, rollout_total_steps, non-finite gradient drift |
+| p1-stability-batch-1 | PPO/Telemetry Stability Batch 1 | ready-for-pr | 🔴 critical | M | high | Locally complete: six bugs closed, broad gates passed |
 | filigree-p0-drain | Critical Filigree P0 Bug Drain | completed-batch | 🔴 critical | L | high | Initial six P0s fixed, verified, and closed |
 | op-value-mismatch | Q(s,op) Double-Sampling Bug | investigation | 🔴 critical | M | high | Diagnosed 2025-12-31, blocks Phase 7. See `docs/bugs/investigations/` |
 

--- a/docs/plans/ready/2026-06-12-green-state-recovery.md
+++ b/docs/plans/ready/2026-06-12-green-state-recovery.md
@@ -30,9 +30,11 @@ status_notes: >
   PR #52 was made green, accepted, and merged as the new baseline on 2026-06-12.
   Main CI passed on merge commit cdff9c43. Recovery PR #72 landed the initial
   P0 Filigree bug drain and project Filigree install removal at merge commit
-  514e04a6. The next active slice is the P1 stability batch covering PPO
-  entropy/KL accounting, rollout telemetry, and non-finite gradient drift.
-percent_complete: 92
+  514e04a6. P1 stability batch 1 is locally complete: six high-priority
+  PPO/telemetry bugs are closed, focused tests passed, broad static gates
+  passed, and the broad Simic sweep passed with known local CUDA/data-fetch
+  exclusions.
+percent_complete: 94
 
 reviewed_by:
   - reviewer: python-engineering
@@ -245,6 +247,13 @@ Status:
 - Completed: initial six P0 issues fixed, verified, and closed.
 - Completed: broad local gates passed where environment permits.
 - Completed: recovery PR #72 merged into `main` at `514e04a6`.
+- Completed: P1 stability batch 1 commit `b4b8f2d0` fixed or verified and closed:
+  - `esper-lite-18eb2f`
+  - `esper-lite-2fcc87`
+  - `esper-lite-5f7f67`
+  - `esper-lite-1bbfb2`
+  - `esper-lite-c82e50`
+  - `esper-lite-ee44b1`
 - Blocked by local CUDA/data fetch: full `tests/simic` includes CUDA CIFAR iterator smoke files that attempted SSL dataset access and timed out locally.
 
 ### H. Drain P1 Stability Batch 1
@@ -272,7 +281,7 @@ Acceptance:
 
 Status:
 
-- Active on branch `codex/p1-stability-batch-1`.
+- Locally complete on branch `codex/p1-stability-batch-1`; pending PR and GitHub checks.
 
 Final local evidence:
 

--- a/docs/plans/ready/2026-06-12-green-state-recovery.md
+++ b/docs/plans/ready/2026-06-12-green-state-recovery.md
@@ -28,10 +28,11 @@ blocks:
 
 status_notes: >
   PR #52 was made green, accepted, and merged as the new baseline on 2026-06-12.
-  Main CI passed on merge commit cdff9c43. The initial P0 Filigree bug drain is
-  complete for the six critical reward, gradient, resume, and attribution
-  defects identified in this recovery program.
-percent_complete: 90
+  Main CI passed on merge commit cdff9c43. Recovery PR #72 landed the initial
+  P0 Filigree bug drain and project Filigree install removal at merge commit
+  514e04a6. The next active slice is the P1 stability batch covering PPO
+  entropy/KL accounting, rollout telemetry, and non-finite gradient drift.
+percent_complete: 92
 
 reviewed_by:
   - reviewer: python-engineering
@@ -72,6 +73,14 @@ Return the project to a steady state:
   - `esper-lite-b765c2` missing slot config validation on resume
   - `esper-lite-30e631` pair attribution order mismatch
   - `esper-lite-102ff8` FP16-scaled gradients collected before unscale
+- Recovery PR #72 (`codex/steady-state-recovery`) was merged into `main` on
+  2026-06-12 at merge commit `514e04a6d7235eba0ef61a147477f7768448730f`.
+- PR #72 verification run `27414100263` passed:
+  - `lint`
+  - `typecheck`
+  - `property-tests`
+  - `unit-and-integration-tests`
+  - `e2e-smoke-tests`
 - The working tree also contains unrelated dirty skill/config files. These must not be reverted or silently included in the PR #52 stabilization commit.
 
 ## Definition Of Green
@@ -235,7 +244,35 @@ Status:
 
 - Completed: initial six P0 issues fixed, verified, and closed.
 - Completed: broad local gates passed where environment permits.
+- Completed: recovery PR #72 merged into `main` at `514e04a6`.
 - Blocked by local CUDA/data fetch: full `tests/simic` includes CUDA CIFAR iterator smoke files that attempted SSL dataset access and timed out locally.
+
+### H. Drain P1 Stability Batch 1
+
+Owner: primary agent with read-only specialist subagents.
+
+Scope:
+
+- Fix or close as stale the first six claimed P1 issues:
+  - `esper-lite-18eb2f` entropy floor schedule inversion
+  - `esper-lite-2fcc87` epoch-0 KL no-step accounting
+  - `esper-lite-5f7f67` zero-availability entropy floor penalty
+  - `esper-lite-1bbfb2` zero-mask KL weighting dilution
+  - `esper-lite-c82e50` `rollout_total_steps` after buffer clear
+  - `esper-lite-ee44b1` non-finite gradient drift poisoning
+- Keep the branch limited to PPO math, PPO coordinator, gradient EMA, tests,
+  and plan/tracker updates.
+
+Acceptance:
+
+- Every claimed issue has focused regression evidence or a stale-issue closure
+  comment referencing current tests.
+- Branch gates pass locally.
+- GitHub PR checks pass before merge.
+
+Status:
+
+- Active on branch `codex/p1-stability-batch-1`.
 
 Final local evidence:
 

--- a/docs/plans/ready/2026-06-12-p1-stability-batch-1.md
+++ b/docs/plans/ready/2026-06-12-p1-stability-batch-1.md
@@ -12,6 +12,8 @@
 - Branch from current `origin/main`: `codex/p1-stability-batch-1`.
 - Claimed Filigree issues: `esper-lite-18eb2f`, `esper-lite-2fcc87`, `esper-lite-5f7f67`, `esper-lite-1bbfb2`, `esper-lite-c82e50`, `esper-lite-ee44b1`.
 - Preserve unrelated dirty files in `/home/john/esper-lite`; do all code edits in `/home/john/.config/superpowers/worktrees/esper-lite/codex-steady-state-recovery`.
+- Implementation commit: `b4b8f2d0`.
+- Filigree status: all six issues closed after `fixing -> verifying -> closed`.
 
 ---
 
@@ -109,7 +111,7 @@
 
 ## Verification
 
-Run the focused gate first:
+Focused gate:
 
 ```bash
 PYTHONPATH=src uv run pytest tests/simic/agent/test_ppo_entropy_floor.py tests/simic/test_ppo.py tests/simic/training/test_ppo_coordinator.py tests/simic/test_gradient_ema.py -q
@@ -118,11 +120,36 @@ MYPYPATH=src uv run mypy -p esper
 uv run python scripts/lint_defensive_patterns.py
 ```
 
-Then run the broader recovery gate before opening the PR:
+Result:
+
+- Passed: `39 passed in 1.26s`.
+- Passed: touched-file Ruff.
+- Passed: targeted mypy on touched source files.
+- Passed: `uv run python scripts/lint_defensive_patterns.py`.
+
+Broad recovery gate:
 
 ```bash
 uv run ruff check src/ tests/
+uv run ruff check scripts/
 uv run python scripts/lint_leyline_types.py
 uv run python scripts/lint_gpu_sync.py
+MYPYPATH=src uv run mypy -p esper
 PYTHONPATH=src uv run pytest tests/simic --ignore=tests/simic/test_data_opt.py --ignore=tests/simic/test_record_stream_fix.py --ignore=tests/simic/training/test_dual_ab.py -q
 ```
+
+Result:
+
+- Passed: `uv run ruff check src/ tests/`.
+- Passed: `uv run ruff check scripts/`.
+- Passed: `uv run python scripts/lint_leyline_types.py`.
+- Passed: `uv run python scripts/lint_gpu_sync.py`.
+- Passed: `MYPYPATH=src uv run mypy -p esper` (`195 source files`).
+- Passed: Simic broad sweep with known local CUDA/data-fetch exclusions (`1107 passed, 4 warnings in 29.70s`).
+
+## Execution Log
+
+- 2026-06-12: Claimed six P1 bugs in Filigree.
+- 2026-06-12: Read-only subagents reviewed PPO loss/KL math and coordinator gradient telemetry.
+- 2026-06-12: Implemented and committed `b4b8f2d0`.
+- 2026-06-12: Verified locally and closed all six Filigree issues.

--- a/docs/plans/ready/2026-06-12-p1-stability-batch-1.md
+++ b/docs/plans/ready/2026-06-12-p1-stability-batch-1.md
@@ -1,0 +1,128 @@
+# P1 Stability Batch 1 Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Close the first post-baseline P1 stability batch so PPO update accounting, entropy/KL metrics, rollout telemetry, and gradient drift tracking cannot silently report healthy data for invalid training states.
+
+**Architecture:** This is a bounded stabilization slice on top of merged recovery PR #72. Keep changes in Simic PPO math/coordinator modules, add focused regression tests, and close each Filigree issue only after the code is committed and verified.
+
+**Tech Stack:** Python 3.11, PyTorch, pytest, Ruff, mypy, Filigree.
+
+**Prerequisites:**
+- Branch from current `origin/main`: `codex/p1-stability-batch-1`.
+- Claimed Filigree issues: `esper-lite-18eb2f`, `esper-lite-2fcc87`, `esper-lite-5f7f67`, `esper-lite-1bbfb2`, `esper-lite-c82e50`, `esper-lite-ee44b1`.
+- Preserve unrelated dirty files in `/home/john/esper-lite`; do all code edits in `/home/john/.config/superpowers/worktrees/esper-lite/codex-steady-state-recovery`.
+
+---
+
+## Task 1: PPO Entropy Schedule Bounds
+
+**Files:**
+- Modify: `src/esper/simic/agent/ppo_agent.py`
+- Test: `tests/simic/agent/test_ppo_entropy_floor.py`
+
+**Steps:**
+1. Add tests proving `total_train_steps=0` is rejected and progress beyond 100% still produces the late-training floor, not a negative multiplier.
+2. Validate `total_train_steps > 0` in `PPOAgent.__init__`.
+3. Clamp progress at the schedule boundary used by `update()`.
+
+**Definition of Done:**
+- `esper-lite-18eb2f` cannot reproduce.
+- Schedule factor remains in `[0.5, 1.5]` even when `train_steps > total_train_steps`.
+
+## Task 2: PPO KL No-Step Contract
+
+**Files:**
+- Inspect/modify if needed: `src/esper/simic/agent/ppo_agent.py`
+- Inspect/modify if needed: `src/esper/simic/agent/ppo_metrics.py`
+- Test: `tests/simic/test_ppo.py`
+- Test: `tests/simic/training/test_ppo_coordinator.py`
+
+**Steps:**
+1. Verify the current epoch-0 KL abort path counts optimizer steps, not ratio-stat epochs.
+2. If already implemented, add tracker comments and close `esper-lite-2fcc87` as fixed by existing code on `main`.
+3. If gaps remain, preserve the no-step contract: `ppo_update_performed=False`, loss fields `NaN`, no `ppo_grad_norm` requirement in coordinator.
+
+**Definition of Done:**
+- Existing or new regression proves epoch-0 KL abort does not advance as a performed PPO update.
+
+## Task 3: Zero-Availability Entropy Floor
+
+**Files:**
+- Modify: `src/esper/simic/agent/ppo_update.py`
+- Test: `tests/simic/agent/test_ppo_entropy_floor.py`
+
+**Steps:**
+1. Write a failing `compute_losses()` regression where a head has zero availability and low entropy.
+2. Route per-step entropy plus effective availability masks into `compute_entropy_floor_penalty()` without precomputing a clamped zero mean.
+3. Keep forced-action masking behavior intact.
+
+**Definition of Done:**
+- `esper-lite-5f7f67` cannot reproduce.
+- Unavailable heads add no entropy-floor penalty.
+
+## Task 4: Zero-Mask KL Weighting
+
+**Files:**
+- Modify: `src/esper/simic/agent/ppo_update.py`
+- Test: `tests/simic/agent/test_ppo_ratio_metrics.py` or an existing PPO math test file.
+
+**Steps:**
+1. Add a regression with one valid high-KL head and one all-zero mask head.
+2. Remove the artificial denominator contribution from zero-mask heads in `compute_ratio_metrics()`.
+3. Keep the all-zero-mask case finite and explicit.
+
+**Definition of Done:**
+- `esper-lite-1bbfb2` cannot reproduce.
+- All-zero heads contribute zero weight, not zero KL with positive weight.
+
+## Task 5: Rollout Total Steps
+
+**Files:**
+- Modify: `src/esper/simic/training/ppo_coordinator.py`
+- Test: `tests/simic/training/test_ppo_coordinator.py`
+
+**Steps:**
+1. Capture `rollout_total_steps` before `run_ppo_updates_fn()` can clear the buffer.
+2. Preserve existing skipped-update behavior.
+3. Add a regression where the update function clears the buffer and the metric still reports pre-update length.
+
+**Definition of Done:**
+- `esper-lite-c82e50` cannot reproduce.
+
+## Task 6: Non-Finite Gradient Drift
+
+**Files:**
+- Modify: `src/esper/simic/training/ppo_coordinator.py`
+- Modify: `src/esper/simic/telemetry/gradient_ema.py`
+- Test: `tests/simic/training/test_ppo_coordinator.py`
+- Test: `tests/simic/test_gradient_ema.py`
+
+**Steps:**
+1. Add tests proving `NaN` and `Inf` gradient norms do not update EMA state.
+2. Return unhealthy drift metrics for non-finite norms without corrupting the tracker.
+3. Reject non-finite inputs directly inside `GradientEMATracker.update()`.
+
+**Definition of Done:**
+- `esper-lite-ee44b1` cannot reproduce.
+- EMA state remains finite after non-finite gradient observations.
+
+## Verification
+
+Run the focused gate first:
+
+```bash
+PYTHONPATH=src uv run pytest tests/simic/agent/test_ppo_entropy_floor.py tests/simic/test_ppo.py tests/simic/training/test_ppo_coordinator.py tests/simic/test_gradient_ema.py -q
+uv run ruff check src/esper/simic/agent/ppo_agent.py src/esper/simic/agent/ppo_update.py src/esper/simic/training/ppo_coordinator.py src/esper/simic/telemetry/gradient_ema.py tests/simic/agent/test_ppo_entropy_floor.py tests/simic/test_ppo.py tests/simic/training/test_ppo_coordinator.py tests/simic/test_gradient_ema.py
+MYPYPATH=src uv run mypy -p esper
+uv run python scripts/lint_defensive_patterns.py
+```
+
+Then run the broader recovery gate before opening the PR:
+
+```bash
+uv run ruff check src/ tests/
+uv run python scripts/lint_leyline_types.py
+uv run python scripts/lint_gpu_sync.py
+PYTHONPATH=src uv run pytest tests/simic --ignore=tests/simic/test_data_opt.py --ignore=tests/simic/test_record_stream_fix.py --ignore=tests/simic/training/test_dual_ab.py -q
+```

--- a/src/esper/simic/agent/ppo_agent.py
+++ b/src/esper/simic/agent/ppo_agent.py
@@ -224,6 +224,8 @@ class PPOAgent:
             probability_floor if probability_floor is not None
             else dict(PROBABILITY_FLOOR_PER_HEAD)
         )
+        if total_train_steps is not None and total_train_steps <= 0:
+            raise ValueError(f"total_train_steps must be positive, got {total_train_steps}")
         self.total_train_steps = total_train_steps if total_train_steps is not None else 1_000_000
         self.value_coef = value_coef
         # Value warmup: start at 10% of target by default, ramp up over warmup_steps
@@ -418,6 +420,7 @@ class PPOAgent:
         Returns:
             Schedule factor [0.5, 1.5]
         """
+        progress = min(1.0, max(0.0, progress))
         if progress < 0.25:
             # Early training: 1.5x boost to establish exploration
             return 1.5

--- a/src/esper/simic/agent/ppo_update.py
+++ b/src/esper/simic/agent/ppo_update.py
@@ -76,8 +76,8 @@ def compute_ratio_metrics(
             mask = head_masks[key]
             log_ratio_clamped = log_ratios_for_joint[key]
             kl_per_step = (torch.exp(log_ratio_clamped) - 1) - log_ratio_clamped
-            n_valid = mask.sum().float().clamp(min=1)
-            head_kl = (kl_per_step * mask).sum() / n_valid
+            n_valid = mask.sum().float()
+            head_kl = (kl_per_step * mask).sum() / n_valid.clamp(min=1)
             causal_weight = n_valid / total_timesteps
             weighted_kl_sum = weighted_kl_sum + causal_weight * head_kl
             total_weight = total_weight + causal_weight
@@ -320,12 +320,14 @@ def compute_losses(
         mean_entropy: dict[str, torch.Tensor] = {}
         for key in entropy:
             # Use availability mask for entropy measurement
-            mask = entropy_masks.get(key, head_masks[key])
+            mask = entropy_masks[key]
             if actor_weight is not None:
                 effective_mask = mask * actor_weight
             else:
                 effective_mask = mask
-            n_available = effective_mask.sum().clamp(min=1)
+            n_available = effective_mask.sum()
+            if n_available < 1:
+                continue
             mean_entropy[key] = (entropy[key] * effective_mask).sum() / n_available
 
         # entropy_floor_penalty_coef is ALWAYS dict - caller normalizes at init time

--- a/src/esper/simic/telemetry/gradient_ema.py
+++ b/src/esper/simic/telemetry/gradient_ema.py
@@ -13,6 +13,7 @@ Why EMA for gradients:
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import math
 
 
 @dataclass(slots=True)
@@ -46,6 +47,11 @@ class GradientEMATracker:
         Returns:
             Dict with ema values and drift indicators
         """
+        if not math.isfinite(grad_norm):
+            raise ValueError(f"grad_norm must be finite, got {grad_norm}")
+        if not math.isfinite(grad_health):
+            raise ValueError(f"grad_health must be finite, got {grad_health}")
+
         self._update_count += 1
 
         if not self._initialized:

--- a/src/esper/simic/training/ppo_coordinator.py
+++ b/src/esper/simic/training/ppo_coordinator.py
@@ -185,6 +185,7 @@ class PPOCoordinator:
         if len(self.agent.buffer) == 0:
             return {}, True, None
 
+        rollout_total_steps = len(self.agent.buffer)
         update_start = time.perf_counter()
         metrics = self.run_ppo_updates_fn(
             agent=self.agent,
@@ -201,7 +202,7 @@ class PPOCoordinator:
             metrics["ppo_update_time_ms"] = ppo_update_time_ms
             metrics["rollout_length"] = self.config.max_epochs
             metrics["rollout_episodes"] = envs_this_batch
-            metrics["rollout_total_steps"] = len(self.agent.buffer)
+            metrics["rollout_total_steps"] = rollout_total_steps
             metrics["reward_mode"] = self.env_reward_configs[0].reward_mode.value
             metrics["reward_family"] = self.reward_family_enum.value
             metrics["entropy_coef"] = self.agent.entropy_coef
@@ -260,6 +261,9 @@ class PPOCoordinator:
         """
         if grad_ema_tracker is None or ppo_grad_norm is None:
             return None
+
+        if not math.isfinite(ppo_grad_norm):
+            raise ValueError(f"ppo_grad_norm must be finite, got {ppo_grad_norm}")
 
         # Compute gradient health (0-1)
         if ppo_grad_norm < 1e-7:

--- a/tests/simic/agent/test_ppo_entropy_floor.py
+++ b/tests/simic/agent/test_ppo_entropy_floor.py
@@ -291,6 +291,49 @@ class TestEntropyFloorIntegration:
         assert losses_higher_blueprint.entropy_floor_penalty > losses_uniform.entropy_floor_penalty
         assert losses_higher_blueprint.total_loss > losses_uniform.total_loss
 
+    def test_compute_losses_skips_entropy_floor_for_zero_availability_head(self) -> None:
+        """A head with no available decisions must not receive entropy-floor penalty."""
+        device = torch.device("cpu")
+        batch_size = 8
+        head_names = ("op", "blueprint")
+
+        per_head_ratios = {k: torch.ones(batch_size, device=device) for k in head_names}
+        per_head_advantages = {k: torch.zeros(batch_size, device=device) for k in head_names}
+        head_masks = {k: torch.ones(batch_size, device=device) for k in head_names}
+        values = torch.zeros(batch_size, device=device)
+        normalized_returns = torch.zeros(batch_size, device=device)
+        old_values = torch.zeros(batch_size, device=device)
+        entropy = {
+            "op": torch.full((batch_size,), 0.5, device=device),
+            "blueprint": torch.full((batch_size,), 0.0, device=device),
+        }
+        availability_masks = {
+            "op": torch.ones(batch_size, device=device),
+            "blueprint": torch.zeros(batch_size, device=device),
+        }
+
+        losses = compute_losses(
+            per_head_ratios=per_head_ratios,
+            per_head_advantages=per_head_advantages,
+            head_masks=head_masks,
+            values=values,
+            normalized_returns=normalized_returns,
+            old_values=old_values,
+            entropy=entropy,
+            entropy_coef_per_head={"op": 1.0, "blueprint": 1.0},
+            entropy_coef=0.01,
+            clip_ratio=0.2,
+            clip_value=False,
+            value_clip=0.2,
+            value_coef=0.5,
+            head_names=head_names,
+            entropy_floor={"op": 0.4, "blueprint": 0.4},
+            entropy_floor_penalty_coef={"op": 0.1, "blueprint": 0.1},
+            availability_masks=availability_masks,
+        )
+
+        assert losses.entropy_floor_penalty.item() == pytest.approx(0.0)
+
 
 class TestPenaltySchedule:
     """Tests for three-phase penalty schedule in PPOAgent.
@@ -434,6 +477,47 @@ class TestPenaltySchedule:
         for progress in [0.0, 0.10, 0.24, 0.25, 0.5, 0.74, 0.75, 0.8, 0.9, 0.99, 1.0]:
             factor = agent._get_penalty_schedule(progress)
             assert 0.5 <= factor <= 1.5, f"Schedule factor {factor} out of bounds at progress {progress}"
+
+    def test_schedule_clamps_progress_above_one(self) -> None:
+        """Overrunning planned train steps must not invert entropy penalty into reward."""
+        from esper.simic.agent.ppo_agent import PPOAgent
+        from esper.tamiyo.policy.factory import create_policy
+        from esper.leyline.slot_config import SlotConfig
+
+        slot_config = SlotConfig.for_grid(2, 2)
+        policy = create_policy(
+            policy_type="lstm",
+            slot_config=slot_config,
+            device="cpu",
+        )
+        agent = PPOAgent(
+            policy=policy,
+            slot_config=slot_config,
+            device="cpu",
+        )
+
+        assert agent._get_penalty_schedule(1.5) == pytest.approx(0.5)
+
+    def test_total_train_steps_must_be_positive(self) -> None:
+        """Zero total_train_steps would make update progress undefined."""
+        from esper.simic.agent.ppo_agent import PPOAgent
+        from esper.tamiyo.policy.factory import create_policy
+        from esper.leyline.slot_config import SlotConfig
+
+        slot_config = SlotConfig.for_grid(2, 2)
+        policy = create_policy(
+            policy_type="lstm",
+            slot_config=slot_config,
+            device="cpu",
+        )
+
+        with pytest.raises(ValueError, match="total_train_steps"):
+            PPOAgent(
+                policy=policy,
+                slot_config=slot_config,
+                device="cpu",
+                total_train_steps=0,
+            )
 
     def test_schedule_applied_to_coefficients_in_update(self) -> None:
         """Verify that schedule factor is applied to coefficients during update."""

--- a/tests/simic/agent/test_ppo_ratio_metrics.py
+++ b/tests/simic/agent/test_ppo_ratio_metrics.py
@@ -1,0 +1,67 @@
+"""Tests for PPO ratio and KL metric edge cases."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from esper.simic.agent.ppo_update import compute_ratio_metrics
+
+
+def test_zero_mask_head_does_not_dilute_approx_kl() -> None:
+    """All-zero causal heads contribute no denominator weight to approx_kl."""
+    old_log_probs = {
+        "op": torch.zeros(4),
+        "slot": torch.zeros(4),
+    }
+    log_probs = {
+        "op": torch.full((4,), 0.5),
+        "slot": torch.full((4,), 10.0),
+    }
+    head_masks = {
+        "op": torch.ones(4),
+        "slot": torch.zeros(4),
+    }
+
+    metrics = compute_ratio_metrics(
+        log_probs=log_probs,
+        old_log_probs=old_log_probs,
+        head_masks=head_masks,
+        clip_ratio=0.2,
+        target_kl=0.09,
+        head_names=("op", "slot"),
+        total_timesteps=torch.tensor(4.0),
+    )
+
+    expected_op_kl = (torch.exp(torch.tensor(0.5)) - 1.0) - 0.5
+    assert metrics.approx_kl.item() == pytest.approx(expected_op_kl.item())
+    assert metrics.early_stop.item() is True
+
+
+def test_all_zero_masks_produce_finite_zero_approx_kl() -> None:
+    """A fully masked batch has no KL weight and should report explicit zero KL."""
+    old_log_probs = {
+        "op": torch.zeros(4),
+        "slot": torch.zeros(4),
+    }
+    log_probs = {
+        "op": torch.full((4,), 0.5),
+        "slot": torch.full((4,), 0.5),
+    }
+    head_masks = {
+        "op": torch.zeros(4),
+        "slot": torch.zeros(4),
+    }
+
+    metrics = compute_ratio_metrics(
+        log_probs=log_probs,
+        old_log_probs=old_log_probs,
+        head_masks=head_masks,
+        clip_ratio=0.2,
+        target_kl=None,
+        head_names=("op", "slot"),
+        total_timesteps=torch.tensor(4.0),
+    )
+
+    assert torch.isfinite(metrics.approx_kl)
+    assert metrics.approx_kl.item() == pytest.approx(0.0)

--- a/tests/simic/test_gradient_ema.py
+++ b/tests/simic/test_gradient_ema.py
@@ -1,5 +1,7 @@
 """Tests for GradientEMATracker (B7-DRL-01)."""
 
+import math
+
 import pytest
 
 from esper.simic.telemetry import GradientEMATracker
@@ -108,3 +110,39 @@ class TestGradientEMATracker:
         # Fast tracker moved more (0.5 * 10 + 0.5 * 20 = 15.0)
         assert slow_metrics["ema_grad_norm"] == pytest.approx(10.1, rel=1e-6)
         assert fast_metrics["ema_grad_norm"] == pytest.approx(15.0, rel=1e-6)
+
+    def test_update_rejects_nan_grad_norm_without_state_change(self):
+        """NaN gradient norms must fail before corrupting EMA state."""
+        tracker = GradientEMATracker()
+        tracker.update(grad_norm=10.0, grad_health=1.0)
+
+        with pytest.raises(ValueError, match="grad_norm"):
+            tracker.update(grad_norm=float("nan"), grad_health=0.0)
+
+        assert tracker.ema_norm == 10.0
+        assert tracker.ema_health == 1.0
+        assert tracker._update_count == 1
+
+    def test_update_rejects_inf_grad_norm_without_state_change(self):
+        """Inf gradient norms must fail before corrupting EMA state."""
+        tracker = GradientEMATracker()
+        tracker.update(grad_norm=10.0, grad_health=1.0)
+
+        with pytest.raises(ValueError, match="grad_norm"):
+            tracker.update(grad_norm=float("inf"), grad_health=0.0)
+
+        assert tracker.ema_norm == 10.0
+        assert tracker.ema_health == 1.0
+        assert tracker._update_count == 1
+
+    def test_update_rejects_nan_grad_health_without_state_change(self):
+        """NaN health values must fail before corrupting EMA state."""
+        tracker = GradientEMATracker()
+        tracker.update(grad_norm=10.0, grad_health=1.0)
+
+        with pytest.raises(ValueError, match="grad_health"):
+            tracker.update(grad_norm=11.0, grad_health=float("nan"))
+
+        assert math.isfinite(tracker.ema_norm)
+        assert math.isfinite(tracker.ema_health)
+        assert tracker._update_count == 1

--- a/tests/simic/training/test_ppo_coordinator.py
+++ b/tests/simic/training/test_ppo_coordinator.py
@@ -5,14 +5,18 @@ from __future__ import annotations
 import logging
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from esper.simic.training.ppo_coordinator import PPOCoordinator, PPOCoordinatorConfig
 
 
 class _StubBuffer:
+    def __init__(self, length: int = 5) -> None:
+        self.length = length
+
     def __len__(self) -> int:
-        return 5
+        return self.length
 
 
 class _StubAgent:
@@ -72,6 +76,34 @@ def test_run_update_treats_epoch0_kl_abort_as_skipped_update():
     assert ppo_update_time_ms is not None
 
 
+def test_run_update_reports_rollout_total_steps_before_buffer_clear():
+    """rollout_total_steps should reflect the rollout size before PPO clears it."""
+
+    coordinator = None
+
+    def _run_ppo_updates_fn(**_kwargs):
+        assert coordinator is not None
+        coordinator.agent.buffer.length = 0
+        return {
+            "ppo_update_performed": True,
+            "pre_clip_grad_norm": 1.0,
+        }
+
+    coordinator = _make_coordinator(run_ppo_updates_fn=_run_ppo_updates_fn)
+
+    metrics, update_skipped, ppo_update_time_ms = coordinator.run_update(
+        raw_states_for_normalizer_update=[torch.ones(1, 3)],
+        obs_normalizer=SimpleNamespace(update=lambda _tensor: None),
+        envs_this_batch=2,
+        throughput_step_time_ms_sum=10.0,
+        throughput_dataloader_wait_ms_sum=1.0,
+    )
+
+    assert update_skipped is False
+    assert metrics["rollout_total_steps"] == 5
+    assert ppo_update_time_ms is not None
+
+
 def test_check_finiteness_gate_ignores_non_finiteness_skip_without_gradient_step():
     """KL early-stop before backward should not increment the finiteness failure counter."""
 
@@ -88,3 +120,19 @@ def test_check_finiteness_gate_ignores_non_finiteness_skip_without_gradient_step
 
     assert consecutive_failures == 0
     assert should_continue is True
+
+
+@pytest.mark.parametrize("bad_norm", [float("nan"), float("inf"), float("-inf")])
+def test_check_gradient_drift_rejects_non_finite_norm_without_poisoning_tracker(bad_norm):
+    """Non-finite grad norms must fail before entering EMA state."""
+    from esper.simic.telemetry import GradientEMATracker
+
+    coordinator = _make_coordinator(run_ppo_updates_fn=lambda **_kwargs: {})
+    tracker = GradientEMATracker()
+    tracker.update(grad_norm=10.0, grad_health=1.0)
+    state_before = tracker.state_dict()
+
+    with pytest.raises(ValueError, match="ppo_grad_norm must be finite"):
+        coordinator.check_gradient_drift(tracker, bad_norm)
+
+    assert tracker.state_dict() == state_before


### PR DESCRIPTION
## Summary
- closes the first post-baseline P1 stability batch across PPO entropy/KL accounting and coordinator telemetry
- prevents entropy schedule inversion when training overruns planned steps
- prevents zero-availability heads from receiving entropy-floor penalties
- prevents zero-mask heads from diluting approximate KL and hiding early-stop conditions
- preserves rollout_total_steps before PPO update buffer clearing
- rejects non-finite gradient norms before gradient EMA state mutation
- records the batch plan and verification evidence

## Filigree
Closed:
- `esper-lite-18eb2f`
- `esper-lite-2fcc87` (verified stale/fixed by existing epoch-0 KL no-step contract)
- `esper-lite-5f7f67`
- `esper-lite-1bbfb2`
- `esper-lite-c82e50`
- `esper-lite-ee44b1`

## Verification
- `PYTHONPATH=src uv run pytest tests/simic/agent/test_ppo_entropy_floor.py tests/simic/agent/test_ppo_ratio_metrics.py tests/simic/training/test_ppo_coordinator.py tests/simic/test_gradient_ema.py tests/simic/test_ppo.py::test_kl_early_stopping_with_single_epoch -q`
- `uv run ruff check src/esper/simic/agent/ppo_agent.py src/esper/simic/agent/ppo_update.py src/esper/simic/training/ppo_coordinator.py src/esper/simic/telemetry/gradient_ema.py tests/simic/agent/test_ppo_entropy_floor.py tests/simic/agent/test_ppo_ratio_metrics.py tests/simic/training/test_ppo_coordinator.py tests/simic/test_gradient_ema.py`
- `MYPYPATH=src uv run mypy src/esper/simic/agent/ppo_agent.py src/esper/simic/agent/ppo_update.py src/esper/simic/training/ppo_coordinator.py src/esper/simic/telemetry/gradient_ema.py`
- `uv run python scripts/lint_defensive_patterns.py`
- `uv run ruff check src/ tests/`
- `uv run ruff check scripts/`
- `uv run python scripts/lint_leyline_types.py`
- `uv run python scripts/lint_gpu_sync.py`
- `MYPYPATH=src uv run mypy -p esper`
- `PYTHONPATH=src uv run pytest tests/simic --ignore=tests/simic/test_data_opt.py --ignore=tests/simic/test_record_stream_fix.py --ignore=tests/simic/training/test_dual_ab.py -q`

## Notes
The full local Simic sweep still excludes the same CUDA/data-fetch smoke files documented in the recovery plan.
