### PR TITLE
Fix telemetry MCP DuckDB path SQL injection

### DIFF
--- a/src/esper/karn/mcp/views.py
+++ b/src/esper/karn/mcp/views.py
@@ -585,6 +585,11 @@ def _create_empty_raw_events_view(conn: duckdb.DuckDBPyConnection) -> None:
     """)
 
 
+def _duckdb_sql_string(value: str) -> str:
+    """Escape a value for placement inside an existing DuckDB SQL string literal."""
+    return value.replace("'", "''")
+
+
 def create_views(conn: duckdb.DuckDBPyConnection, telemetry_dir: str) -> None:
     """Create all telemetry views on the given connection.
 
@@ -596,13 +601,14 @@ def create_views(conn: duckdb.DuckDBPyConnection, telemetry_dir: str) -> None:
     conn.execute("PRAGMA disable_progress_bar")
 
     has_files = telemetry_has_event_files(telemetry_dir)
+    telemetry_dir_sql = _duckdb_sql_string(telemetry_dir)
 
     for view_name, view_sql in VIEW_DEFINITIONS.items():
         if view_name == "raw_events" and not has_files:
             _create_empty_raw_events_view(conn)
             continue
 
-        sql = view_sql.format(telemetry_dir=telemetry_dir)
+        sql = view_sql.format(telemetry_dir=telemetry_dir_sql)
         try:
             conn.execute(sql)
         except duckdb.IOException as e:

--- a/tests/karn/mcp/test_views.py
+++ b/tests/karn/mcp/test_views.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import duckdb
+import pytest
 
 from esper.karn.mcp.views import create_views, VIEW_DEFINITIONS
 
@@ -598,3 +599,19 @@ def test_batch_epochs_and_trends_views_parse_payloads(tmp_path):
         "SELECT event_type, batch_idx, rolling_delta FROM trends"
     ).fetchone()
     assert trend_row == ("PLATEAU_DETECTED", 4, 0.001)
+
+
+def test_create_views_escapes_telemetry_dir_sql_literal(tmp_path):
+    injected_table = "injected_by_path"
+    telemetry_dir = tmp_path / f"telemetry'; CREATE TABLE {injected_table} AS SELECT 1; --"
+    run_dir = telemetry_dir / "run-a"
+    run_dir.mkdir(parents=True)
+    events_file = run_dir / "events.jsonl"
+    events_file.write_text('{"event_id": "evt-1", "event_type": "TEST"}\n')
+
+    conn = duckdb.connect(":memory:")
+    create_views(conn, str(telemetry_dir))
+
+    assert conn.execute("SELECT event_id FROM raw_events").fetchone() == ("evt-1",)
+    with pytest.raises(duckdb.CatalogException):
+        conn.execute(f"SELECT * FROM {injected_table}")


### PR DESCRIPTION
## Summary
- replaces stale PR #70 with a clean current-main security patch
- escapes `telemetry_dir` before inserting it into DuckDB SQL string literals used by Karn MCP views
- adds a regression path whose directory name attempts to inject `CREATE TABLE`, then proves no injected table exists

## Verification
- `PYTHONPATH=src uv run pytest tests/karn/mcp/test_views.py::test_create_views_escapes_telemetry_dir_sql_literal -q`
- `PYTHONPATH=src uv run pytest tests/karn/mcp -q`
- `PYTHONPATH=src uv run pytest tests/karn/sanctum/test_app_integration.py::test_sanctum_app_shows_multiple_tamiyo_widgets -q`
- `uv run ruff check src/ tests/`
- `MYPYPATH=src uv run mypy -p esper`
- `uv run python scripts/lint_defensive_patterns.py`

## Notes
- `wardline scan . --fail-on ERROR` could not run because this environment has `wardline` without the scanner extra: `the wardline CLI requires the scanner extra; install wardline[scanner]`.
- The old PR #70 also carried stale Sanctum/coverage changes; the current Sanctum regression passes on main without those changes, so this branch keeps only the SQL injection fix.
