### PR TITLE
fix(simic): resolve p1 stability regressions

### DIFF
--- a/src/esper/simic/telemetry/anomaly_detector.py
+++ b/src/esper/simic/telemetry/anomaly_detector.py
@@ -419,6 +419,13 @@ class AnomalyDetector:
             threshold = thresholds.get(head, 0.1)  # Default fallback
             current_streak = self._head_collapse_streak.get(head, 0)
 
+            if not math.isfinite(entropy):
+                report.add_anomaly(
+                    f"entropy_nan_inf_{head}",
+                    f"{head} entropy={entropy} is non-finite",
+                )
+                continue
+
             if entropy < threshold:
                 # Increment streak
                 current_streak += 1

--- a/src/esper/simic/training/config.py
+++ b/src/esper/simic/training/config.py
@@ -315,7 +315,6 @@ class TrainingConfig:
             "value_coef": self.value_coef,
             "value_coef_start": self.value_coef_start,
             "value_warmup_steps": value_warmup_steps,
-            "lstm_hidden_dim": self.lstm_hidden_dim,
             "chunk_length": self.chunk_length,
             "num_envs": self.n_envs,
             "max_steps_per_env": self.max_epochs,

--- a/src/esper/simic/training/env_factory.py
+++ b/src/esper/simic/training/env_factory.py
@@ -46,6 +46,31 @@ class EpisodeContext:
         self.episode_idx: int | None = None
 
 
+ENV_SEED_STRIDE = 1009
+AUGMENT_SEED_OFFSET = 1
+
+
+def make_env_seed(
+    *,
+    root_seed: int,
+    batch_idx: int,
+    env_idx: int,
+    envs_per_batch: int,
+) -> int:
+    """Create the exact seed for one vectorized environment."""
+    if batch_idx < 0:
+        raise ValueError(f"batch_idx must be non-negative, got {batch_idx}")
+    if envs_per_batch <= 0:
+        raise ValueError(f"envs_per_batch must be positive, got {envs_per_batch}")
+    if env_idx < 0 or env_idx >= envs_per_batch:
+        raise ValueError(
+            f"env_idx must be in [0, {envs_per_batch}), got {env_idx}"
+        )
+
+    stream_idx = batch_idx * envs_per_batch + env_idx
+    return root_seed + stream_idx * ENV_SEED_STRIDE
+
+
 def make_telemetry_callback(
     env_idx: int,
     device: str,
@@ -106,7 +131,7 @@ class EnvFactoryContext:
 
 def create_env_state(
     env_idx: int,
-    base_seed: int,
+    env_seed: int,
     context: EnvFactoryContext,
 ) -> ParallelEnvState:
     """Create environment state with CUDA stream.
@@ -114,8 +139,8 @@ def create_env_state(
     DataLoaders are now shared via SharedBatchIterator, not per-env.
     """
     env_device = context.env_device_map[env_idx]
-    torch.manual_seed(base_seed + env_idx * 1000)
-    random.seed(base_seed + env_idx * 1000)
+    torch.manual_seed(env_seed)
+    random.seed(env_seed)
 
     model_raw = context.create_model(
         task=context.task_spec,
@@ -174,7 +199,7 @@ def create_env_state(
     augment_buffers = None
     if context.gpu_preload_augment:
         augment_generator = torch.Generator(device=env_device)
-        augment_generator.manual_seed(base_seed + env_idx * 1009)
+        augment_generator.manual_seed(env_seed + AUGMENT_SEED_OFFSET)
         # Pre-allocate buffers to reduce memory fragmentation during augmentation.
         # The ensure_capacity() method handles resizing if batch size changes.
         augment_buffers = AugmentationBuffers(device=env_device)
@@ -229,14 +254,14 @@ def create_env_state(
     )
 
     # Create CounterfactualHelper for Shapley value analysis at episode end
-    # Use base_seed for reproducible Shapley permutation sampling (B5-CR-01)
+    # Use env_seed for reproducible Shapley permutation sampling (B5-CR-01)
     # Pass telemetry_cb for per-env context (same pattern as HealthMonitor)
     counterfactual_helper = (
         CounterfactualHelper(
             strategy="auto",  # Full factorial for <=4 slots, Shapley sampling otherwise
             shapley_samples=20,
             emit_callback=telemetry_cb,  # Pre-wired with env context
-            seed=base_seed,
+            seed=env_seed,
         )
         if context.use_telemetry
         else None

--- a/src/esper/simic/training/ppo_coordinator.py
+++ b/src/esper/simic/training/ppo_coordinator.py
@@ -157,7 +157,8 @@ class PPOCoordinator:
                 stability = 1.0
 
             # 4. Find and replace EpisodeOutcome for this env
-            for idx, outcome in enumerate(episode_outcomes):
+            for idx in range(len(episode_outcomes) - 1, -1, -1):
+                outcome = episode_outcomes[idx]
                 if outcome.env_id == env_idx:
                     corrected_outcome = dataclasses.replace(
                         outcome,

--- a/src/esper/simic/training/vectorized_trainer.py
+++ b/src/esper/simic/training/vectorized_trainer.py
@@ -36,7 +36,12 @@ from esper.utils.data import augment_cifar10_batch
 from .action_execution import ActionExecutionContext, ResolveTargetSlot, execute_actions
 from .batch_ops import batch_signals_to_features, process_train_batch
 from .counterfactual_eval import process_fused_val_batch
-from .env_factory import EnvFactoryContext, configure_slot_telemetry, create_env_state
+from .env_factory import (
+    EnvFactoryContext,
+    configure_slot_telemetry,
+    create_env_state,
+    make_env_seed,
+)
 from .ppo_coordinator import PPOCoordinator, PPOCoordinatorConfig
 from esper.simic.vectorized_types import (
     ActionMaskFlags,
@@ -290,9 +295,17 @@ class VectorizedPPOTrainer:
 
                 # Create fresh environments for this batch
                 # DataLoaders are shared via SharedBatchIterator (not per-env)
-                base_seed = seed + batch_idx * 10000
                 env_states = [
-                    create_env_state(i, base_seed, env_factory)
+                    create_env_state(
+                        i,
+                        make_env_seed(
+                            root_seed=seed,
+                            batch_idx=batch_idx,
+                            env_idx=i,
+                            envs_per_batch=envs_this_batch,
+                        ),
+                        env_factory,
+                    )
                     for i in range(envs_this_batch)
                 ]
                 criterion = nn.CrossEntropyLoss()

--- a/tests/simic/telemetry/test_anomaly_detector.py
+++ b/tests/simic/telemetry/test_anomaly_detector.py
@@ -194,6 +194,16 @@ class TestPerHeadEntropyCollapse:
 
         assert not report.has_anomaly
 
+    def test_nan_entropy_triggers_anomaly_immediately(self) -> None:
+        """NaN entropy must not bypass per-head collapse detection."""
+        detector = AnomalyDetector()
+
+        report = detector.check_per_head_entropy_collapse({"blueprint": float("nan")})
+
+        assert report.has_anomaly
+        assert "entropy_nan_inf_blueprint" in report.anomaly_types
+        assert "entropy=nan" in report.details["entropy_nan_inf_blueprint"]
+
     def test_recovery_requires_margin(self) -> None:
         """Recovery should require entropy above threshold * 1.5."""
         detector = AnomalyDetector()

--- a/tests/simic/test_config.py
+++ b/tests/simic/test_config.py
@@ -5,6 +5,7 @@ import inspect
 import pytest
 
 from esper.simic.rewards import RewardFamily, RewardMode
+from esper.simic.agent import PPOAgent
 from esper.simic.training import TrainingConfig
 from esper.simic.training.vectorized import train_ppo_vectorized
 
@@ -70,7 +71,7 @@ class TestTrainingConfigConversion:
     """Tests for TrainingConfig to kwargs conversion methods."""
 
     def test_lstm_config_to_ppo_kwargs(self):
-        """LSTM params should flow to PPOAgent kwargs."""
+        """LSTM sizing is policy construction input, not a PPOAgent kwarg."""
         config = TrainingConfig(
             lstm_hidden_dim=256,
             max_epochs=25,  # chunk_length must match max_epochs
@@ -80,7 +81,7 @@ class TestTrainingConfigConversion:
             ppo_updates_per_batch=2,
         )
         kwargs = config.to_ppo_kwargs()
-        assert kwargs["lstm_hidden_dim"] == 256
+        assert "lstm_hidden_dim" not in kwargs
         assert kwargs["chunk_length"] == 25
         # ceil(episodes / n_envs) * updates_per_batch
         assert kwargs["entropy_anneal_steps"] == 4
@@ -111,6 +112,16 @@ class TestTrainingConfigConversion:
 
         config = TrainingConfig()
         kwargs = set(config.to_train_kwargs())
+
+        assert kwargs <= allowed
+
+    def test_to_ppo_kwargs_is_subset_of_ppo_agent_signature(self):
+        """Config → PPO kwargs must stay in sync with PPOAgent constructor."""
+        signature = inspect.signature(PPOAgent.__init__)
+        allowed = set(signature.parameters)
+
+        config = TrainingConfig()
+        kwargs = set(config.to_ppo_kwargs())
 
         assert kwargs <= allowed
 

--- a/tests/simic/training/test_env_factory.py
+++ b/tests/simic/training/test_env_factory.py
@@ -1,0 +1,43 @@
+"""Tests for vectorized environment construction helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from esper.simic.training.env_factory import make_env_seed
+
+
+def test_make_env_seed_separates_batches_and_envs() -> None:
+    """Batch and env dimensions should not collide in the seed stream."""
+    root_seed = 1234
+    envs_per_batch = 12
+
+    seeds = {
+        make_env_seed(
+            root_seed=root_seed,
+            batch_idx=batch_idx,
+            env_idx=env_idx,
+            envs_per_batch=envs_per_batch,
+        )
+        for batch_idx in range(2)
+        for env_idx in range(envs_per_batch)
+    }
+
+    assert len(seeds) == 2 * envs_per_batch
+    assert make_env_seed(
+        root_seed=root_seed,
+        batch_idx=0,
+        env_idx=10,
+        envs_per_batch=envs_per_batch,
+    ) != make_env_seed(
+        root_seed=root_seed,
+        batch_idx=1,
+        env_idx=0,
+        envs_per_batch=envs_per_batch,
+    )
+
+
+def test_make_env_seed_rejects_env_index_outside_batch() -> None:
+    """The seed helper should fail when the caller gives an impossible env index."""
+    with pytest.raises(ValueError, match="env_idx"):
+        make_env_seed(root_seed=1234, batch_idx=0, env_idx=4, envs_per_batch=4)

--- a/tests/simic/training/test_ppo_coordinator.py
+++ b/tests/simic/training/test_ppo_coordinator.py
@@ -8,15 +8,21 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from esper.leyline import EpisodeOutcome
 from esper.simic.training.ppo_coordinator import PPOCoordinator, PPOCoordinatorConfig
 
 
 class _StubBuffer:
     def __init__(self, length: int = 5) -> None:
         self.length = length
+        self.penalty_calls: list[tuple[int, float]] = []
 
     def __len__(self) -> int:
         return self.length
+
+    def mark_terminal_with_penalty(self, env_id: int, penalty: float) -> bool:
+        self.penalty_calls.append((env_id, penalty))
+        return True
 
 
 class _StubAgent:
@@ -35,7 +41,7 @@ def _make_coordinator(*, run_ppo_updates_fn):
             amp_enabled=False,
             resolved_amp_dtype=None,
         ),
-        reward_normalizer=SimpleNamespace(),
+        reward_normalizer=SimpleNamespace(normalize_only=lambda reward: reward),
         anomaly_detector=SimpleNamespace(),
         env_reward_configs=[SimpleNamespace(reward_mode=SimpleNamespace(value="basic"))],
         reward_family_enum=SimpleNamespace(value="dense"),
@@ -74,6 +80,56 @@ def test_run_update_treats_epoch0_kl_abort_as_skipped_update():
     assert metrics["ppo_update_performed"] is False
     assert "ppo_grad_norm" not in metrics
     assert ppo_update_time_ms is not None
+
+
+def _make_outcome(env_id: int, episode_idx: int, reward: float) -> EpisodeOutcome:
+    return EpisodeOutcome(
+        env_id=env_id,
+        episode_idx=episode_idx,
+        final_accuracy=0.5,
+        param_ratio=1.0,
+        num_fossilized=0,
+        num_contributing_fossilized=0,
+        episode_reward=reward,
+        stability_score=1.0,
+        reward_mode="basic",
+    )
+
+
+def test_handle_rollbacks_corrects_latest_episode_outcome_for_env():
+    """Rollback correction must update the most recent outcome for the env."""
+    coordinator = _make_coordinator(run_ppo_updates_fn=lambda **_kwargs: {})
+    env_states = [
+        SimpleNamespace(
+            governor=SimpleNamespace(get_punishment_reward=lambda: -10.0),
+            episode_rewards=[1.0, 2.0],
+        )
+    ]
+    env_total_rewards = [3.0]
+    episode_history = [
+        SimpleNamespace(env_id=0, episode_reward=100.0),
+        SimpleNamespace(env_id=0, episode_reward=3.0),
+    ]
+    episode_outcomes = [
+        _make_outcome(env_id=0, episode_idx=1, reward=100.0),
+        _make_outcome(env_id=0, episode_idx=2, reward=3.0),
+    ]
+
+    rollback_envs = coordinator.handle_rollbacks(
+        env_states=env_states,
+        env_rollback_occurred=[True],
+        env_total_rewards=env_total_rewards,
+        episode_history=episode_history,
+        episode_outcomes=episode_outcomes,
+    )
+
+    assert rollback_envs == [0]
+    assert coordinator.agent.buffer.penalty_calls == [(0, -10.0)]
+    assert env_total_rewards == [-9.0]
+    assert episode_history[0].episode_reward == 100.0
+    assert episode_history[1].episode_reward == -9.0
+    assert episode_outcomes[0].episode_reward == 100.0
+    assert episode_outcomes[1].episode_reward == -9.0
 
 
 def test_run_update_reports_rollout_total_steps_before_buffer_clear():


### PR DESCRIPTION
## Summary
- correct rollback outcome adjustment to update the newest matching episode outcome
- remove stale lstm_hidden_dim from PPOAgent kwargs and add constructor-signature contract coverage
- replace overlapping batch/env seed composition with exact per-env seed derivation
- flag non-finite per-head entropy immediately
- verify the duplicate gradient EMA poisoning issue remains fixed by existing coverage

## Filigree
Closes esper-lite-9f0cf1
Closes esper-lite-fd3e7c
Closes esper-lite-58536a
Closes esper-lite-a7d8c3
Closes esper-lite-1e053e

## Verification
- PYTHONPATH=src uv run pytest tests/simic/training/test_ppo_coordinator.py::test_handle_rollbacks_corrects_latest_episode_outcome_for_env tests/simic/test_config.py::TestTrainingConfigConversion::test_lstm_config_to_ppo_kwargs tests/simic/test_config.py::TestTrainingConfigConversion::test_to_ppo_kwargs_is_subset_of_ppo_agent_signature tests/simic/training/test_env_factory.py tests/simic/telemetry/test_anomaly_detector.py::TestPerHeadEntropyCollapse::test_nan_entropy_triggers_anomaly_immediately -q
- PYTHONPATH=src uv run pytest tests/simic/training/test_ppo_coordinator.py tests/simic/test_config.py tests/simic/training/test_env_factory.py tests/simic/telemetry/test_anomaly_detector.py tests/simic/test_gradient_ema.py -q
- PYTHONPATH=src uv run pytest tests/simic --ignore=tests/simic/test_data_opt.py --ignore=tests/simic/test_record_stream_fix.py --ignore=tests/simic/training/test_dual_ab.py -q
- uv run ruff check src/ tests/
- uv run ruff check scripts/
- uv run python scripts/lint_defensive_patterns.py
- uv run python scripts/lint_leyline_types.py
- uv run python scripts/lint_gpu_sync.py
- MYPYPATH=src uv run mypy -p esper