### PR TITLE
fix(simic): preserve exact counterfactual attribution

### DIFF
--- a/src/esper/simic/attribution/counterfactual.py
+++ b/src/esper/simic/attribution/counterfactual.py
@@ -89,6 +89,7 @@ class CounterfactualMatrix:
     epoch: int = 0
     configs: list[CounterfactualResult] = field(default_factory=list)
     strategy_used: str = ""
+    source: Literal["evaluated", "precomputed"] = "evaluated"
     compute_time_seconds: float = 0.0
     failed_configs: int = 0
 
@@ -254,18 +255,7 @@ class CounterfactualEngine:
                 for slot_id, enabled in zip(slot_ids, config_tuple)
             }
 
-            # Evaluate
-            try:
-                val_loss, val_accuracy = evaluate_fn(alpha_settings)
-            except Exception as e:
-                matrix.failed_configs += 1
-                if matrix.failed_configs <= 5:  # Throttle logs
-                    _logger.warning(
-                        "Counterfactual evaluation failed for config %s: %s",
-                        config_tuple,
-                        e,
-                    )
-                continue  # Skip failed evaluations
+            val_loss, val_accuracy = evaluate_fn(alpha_settings)
 
             result = CounterfactualResult(
                 config=config_tuple,
@@ -287,7 +277,7 @@ class CounterfactualEngine:
         """Compute matrix from pre-calculated results (e.g. fused validation)."""
         n_seeds = len(slot_ids)
         strategy = self.config.effective_strategy(n_seeds)
-        matrix = CounterfactualMatrix(strategy_used=strategy)
+        matrix = CounterfactualMatrix(strategy_used=strategy, source="precomputed")
 
         # We assume the results passed in match what generate_configs would request,
         # or at least contain the subsets we care about.
@@ -499,22 +489,41 @@ class CounterfactualEngine:
 
         # f(empty)
         empty = tuple(False for _ in range(n))
-        f_empty = lookup.get(empty, 0.0)
+        if empty not in lookup:
+            raise ValueError(
+                f"Counterfactual matrix missing required configs for interactions: {empty}"
+            )
+        f_empty = lookup[empty]
 
         interactions = {}
         for i in range(n):
             for j in range(i + 1, n):
                 # f({i})
                 config_i = tuple(k == i for k in range(n))
-                f_i = lookup.get(config_i, f_empty)
+                if config_i not in lookup:
+                    raise ValueError(
+                        "Counterfactual matrix missing required configs for "
+                        f"interactions: {config_i}"
+                    )
+                f_i = lookup[config_i]
 
                 # f({j})
                 config_j = tuple(k == j for k in range(n))
-                f_j = lookup.get(config_j, f_empty)
+                if config_j not in lookup:
+                    raise ValueError(
+                        "Counterfactual matrix missing required configs for "
+                        f"interactions: {config_j}"
+                    )
+                f_j = lookup[config_j]
 
                 # f({i,j})
                 config_ij = tuple(k == i or k == j for k in range(n))
-                f_ij = lookup.get(config_ij, f_empty)
+                if config_ij not in lookup:
+                    raise ValueError(
+                        "Counterfactual matrix missing required configs for "
+                        f"interactions: {config_ij}"
+                    )
+                f_ij = lookup[config_ij]
 
                 # Interaction term
                 interaction = f_ij - f_i - f_j + f_empty

--- a/src/esper/simic/attribution/counterfactual_helper.py
+++ b/src/esper/simic/attribution/counterfactual_helper.py
@@ -139,8 +139,8 @@ class CounterfactualHelper:
                 contribution=contribution,
             )
 
-        # Add Shapley values if we have enough configs
-        if len(matrix.configs) > len(slot_ids) + 1:
+        # Add Shapley values when the matrix contains at least off/on states.
+        if len(matrix.configs) >= 2:
             shapley_values = self.engine.compute_shapley_values(matrix)
             for slot_id, estimate in shapley_values.items():
                 if slot_id in results:
@@ -170,6 +170,23 @@ class CounterfactualHelper:
     def last_matrix(self) -> CounterfactualMatrix | None:
         """Get the last computed counterfactual matrix."""
         return self._last_matrix
+
+    def has_precomputed_matrix_for(
+        self,
+        slot_ids: list[str],
+        *,
+        epoch: int,
+    ) -> bool:
+        """Return whether exact precomputed results already exist for this episode."""
+        if self._last_matrix is None:
+            return False
+        if self._last_matrix.source != "precomputed":
+            return False
+        if self._last_matrix.epoch != epoch:
+            return False
+        if not self._last_matrix.configs:
+            return False
+        return self._last_matrix.configs[0].slot_ids == tuple(slot_ids)
 
     def reset(self) -> None:
         """Reset cached state for new episode.

--- a/src/esper/simic/training/action_execution.py
+++ b/src/esper/simic/training/action_execution.py
@@ -1278,6 +1278,16 @@ def execute_actions(
                     and cast(SeedSlotProtocol, model.seed_slots[sid]).alpha > 0
                 ]
                 if active_slot_ids:
+                    shapley_epoch = batch_idx + 1
+                    has_exact_results = (
+                        env_state.counterfactual_helper.has_precomputed_matrix_for(
+                            active_slot_ids,
+                            epoch=shapley_epoch,
+                        )
+                    )
+                    if has_exact_results:
+                        continue
+
                     cached_baselines = baseline_accs[env_idx]
 
                     def eval_fn(alpha_settings: dict[str, float]) -> tuple[float, float]:
@@ -1294,7 +1304,7 @@ def execute_actions(
                             )
                         if disabled:
                             return env_state.val_loss * 1.2, sum(
-                                cached_baselines.get(s, env_state.val_acc)
+                                cached_baselines[s]
                                 for s in disabled
                             ) / len(disabled)
                         return env_state.val_loss, env_state.val_acc
@@ -1303,7 +1313,7 @@ def execute_actions(
                         env_state.counterfactual_helper.compute_contributions(
                             slot_ids=active_slot_ids,
                             evaluate_fn=eval_fn,
-                            epoch=batch_idx + 1,
+                            epoch=shapley_epoch,
                         )
                     except (KeyError, ZeroDivisionError, ValueError) as e:
                         # HIGH-01 fix: Narrow to expected failures in Shapley computation

--- a/tests/simic/attribution/test_counterfactual.py
+++ b/tests/simic/attribution/test_counterfactual.py
@@ -3,6 +3,8 @@
 B5-CR-01 regression tests: verify seeded RNG produces reproducible results.
 """
 
+import pytest
+
 from esper.simic.attribution.counterfactual import (
     CounterfactualConfig,
     CounterfactualEngine,
@@ -299,6 +301,92 @@ class TestZeroSeedEdgeCases:
         # With single seed, Shapley = marginal contribution = 0.7 - 0.5 = 0.2
         assert "r0c0" in shapley
         assert abs(shapley["r0c0"].mean - 0.2) < 0.01
+
+
+class TestCounterfactualInteractions:
+    """Regression coverage for interaction term validity."""
+
+    def test_compute_matrix_propagates_evaluation_failure(self):
+        """Failed required evaluations should not return a partial matrix."""
+        engine = CounterfactualEngine()
+
+        def failing_evaluate(_alpha_settings: dict[str, float]) -> tuple[float, float]:
+            raise RuntimeError("required config failed")
+
+        with pytest.raises(RuntimeError, match="required config failed"):
+            engine.compute_matrix(["r0c0", "r0c1"], failing_evaluate)
+
+    def test_interaction_terms_reject_partial_matrix(self):
+        """Missing required coalitions should not be substituted with 0.0."""
+        engine = CounterfactualEngine()
+        matrix = CounterfactualMatrix(epoch=1, strategy_used="full_factorial")
+        matrix.configs.append(
+            CounterfactualResult(
+                config=(False, False),
+                slot_ids=("r0c0", "r0c1"),
+                val_accuracy=0.50,
+                val_loss=0.50,
+            )
+        )
+        matrix.configs.append(
+            CounterfactualResult(
+                config=(True, True),
+                slot_ids=("r0c0", "r0c1"),
+                val_accuracy=0.80,
+                val_loss=0.20,
+            )
+        )
+
+        with pytest.raises(ValueError, match="missing required configs"):
+            engine.compute_interaction_terms(matrix)
+
+
+class TestCounterfactualHelperShapley:
+    """Regression coverage for helper-level Shapley processing."""
+
+    def test_single_slot_results_compute_shapley(self):
+        """Single-slot full-factorial results should produce Shapley telemetry data."""
+        from esper.leyline import TelemetryEvent
+        from esper.simic.attribution.counterfactual_helper import CounterfactualHelper
+
+        events: list[TelemetryEvent] = []
+        helper = CounterfactualHelper(seed=42, emit_callback=events.append)
+
+        contributions = helper.compute_contributions_from_results(
+            slot_ids=["r0c0"],
+            results={
+                (False,): (0.5, 0.50),
+                (True,): (0.3, 0.70),
+            },
+            epoch=7,
+        )
+
+        assert contributions["r0c0"].contribution == pytest.approx(0.20)
+        assert contributions["r0c0"].shapley_mean == pytest.approx(0.20)
+        assert contributions["r0c0"].shapley_std == pytest.approx(0.0)
+        assert len(events) == 1
+        assert events[0].data.kind == "shapley_computed"
+        assert events[0].data.shapley_values["r0c0"]["mean"] == pytest.approx(0.20)
+
+    def test_precomputed_matrix_marker_matches_slot_ids_and_epoch(self):
+        """Episode-end code needs to know when exact fused results already landed."""
+        from esper.simic.attribution.counterfactual_helper import CounterfactualHelper
+
+        helper = CounterfactualHelper(seed=42, emit_callback=None)
+        helper.compute_contributions_from_results(
+            slot_ids=["r0c0", "r0c1"],
+            results={
+                (False, False): (0.5, 0.50),
+                (True, False): (0.4, 0.60),
+                (False, True): (0.4, 0.65),
+                (True, True): (0.3, 0.75),
+            },
+            epoch=7,
+        )
+
+        assert helper.has_precomputed_matrix_for(["r0c0", "r0c1"], epoch=7)
+        assert not helper.has_precomputed_matrix_for(["r0c1", "r0c0"], epoch=7)
+        assert not helper.has_precomputed_matrix_for(["r0c0", "r0c1"], epoch=8)
 
 
 class TestCounterfactualHelperReset:


### PR DESCRIPTION
## Summary
- fail fast when counterfactual evaluation cannot produce required configs instead of returning partial matrices
- require exact coalition lookups for interaction terms rather than substituting fallback accuracies
- compute Shapley for valid single-slot off/on matrices and assert shapley_computed telemetry
- tag precomputed fused matrices and skip later approximate episode-end recomputation when exact results already exist

## Filigree
Closes esper-lite-2a873b
Closes esper-lite-0e27c9
Closes esper-lite-40266a

## Verification
- PYTHONPATH=src uv run pytest tests/simic/attribution/test_counterfactual.py tests/simic/properties/test_counterfactual_attribution_properties.py tests/simic/training/test_contribution_propagation.py tests/simic/telemetry/test_emitters.py -q
- PYTHONPATH=src uv run pytest tests/simic --ignore=tests/simic/test_data_opt.py --ignore=tests/simic/test_record_stream_fix.py --ignore=tests/simic/training/test_dual_ab.py -q
- uv run ruff check src/ tests/
- uv run ruff check scripts/
- uv run python scripts/lint_defensive_patterns.py
- uv run python scripts/lint_leyline_types.py
- uv run python scripts/lint_gpu_sync.py
- MYPYPATH=src uv run mypy -p esper