### PR TITLE
fix(simic): correct helper training metrics

### DIFF
--- a/src/esper/simic/training/helpers.py
+++ b/src/esper/simic/training/helpers.py
@@ -256,7 +256,7 @@ def _train_one_epoch(
 
     This function extracts the repeated inline loop pattern. Callers use
     returned values to compute metrics:
-        train_loss = running_loss / len(trainloader)
+        train_loss = running_loss / total
         train_acc = 100.0 * correct / total
 
     Args:
@@ -271,7 +271,7 @@ def _train_one_epoch(
 
     Returns:
         Tuple of (running_loss, correct_count, total_count, grad_stats)
-        - running_loss: Sum of loss values across batches (float)
+        - running_loss: Sample-weighted sum of loss values across batches (float)
         - correct_count: Sum of correct predictions (float/int)
         - total_count: Total samples processed (int)
         - grad_stats: GradientHealthStats if collect_gradients=True, else None
@@ -303,8 +303,7 @@ def _train_one_epoch(
             correct_batch = predicted.eq(targets).sum()
             batch_total = targets.size(0)
         else:  # LM task
-            # Use zeros with dtype=long to match classification branch's .sum() output
-            correct_batch = torch.zeros((), device=outputs.device, dtype=torch.long)
+            correct_batch = outputs.argmax(dim=-1).eq(targets).sum()
             batch_total = targets.numel()
         loss.backward()  # type: ignore[no-untyped-call]
 
@@ -324,7 +323,7 @@ def _train_one_epoch(
             seed_optimizer.step()
 
         # Accumulate on device - no .item() sync in hot path
-        running_loss.add_(loss.detach())
+        running_loss.add_(loss.detach() * batch_total)
         running_correct.add_(correct_batch)
         total += batch_total
 
@@ -607,12 +606,12 @@ def run_heuristic_episode(
                 seed_optimizer.step()
 
             # Accumulate on device - no .item() sync in hot path
-            running_loss.add_(loss.detach())
+            running_loss.add_(loss.detach() * batch_total)
             running_correct.add_(correct_batch)
             total += batch_total
 
         # Single sync at end of training
-        train_loss = running_loss.item() / max(1, batch_count)
+        train_loss = running_loss.item() / total if total > 0 else 0.0
         train_acc = 100.0 * running_correct.item() / total if total > 0 else 0.0
 
         # Finalize per-slot gradient stats AFTER the sync above (safe to call .item()).
@@ -642,12 +641,12 @@ def run_heuristic_episode(
                 targets = targets.to(device, non_blocking=True)
                 outputs = model(inputs)
                 loss, correct_batch, batch_total = compute_task_loss_with_metrics(outputs, targets, criterion, task_type)
-                val_loss_accum.add_(loss)
+                val_loss_accum.add_(loss * batch_total)
                 val_correct_accum.add_(correct_batch)
                 total += batch_total
 
         # Single sync at end of validation
-        val_loss = val_loss_accum.item() / max(1, batch_count)
+        val_loss = val_loss_accum.item() / total if total > 0 else 0.0
         val_acc = 100.0 * val_correct_accum.item() / total if total > 0 else 0.0
 
         # Gather active seeds across ALL enabled slots (multi-slot support).

--- a/tests/simic/test_training_helper.py
+++ b/tests/simic/test_training_helper.py
@@ -6,6 +6,17 @@ import torch.nn as nn
 from torch.utils.data import DataLoader, TensorDataset
 
 
+class _LogitReplayModel(nn.Module):
+    """Model that treats inputs as logits while keeping a gradient path."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.dummy = nn.Parameter(torch.zeros(()))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x + self.dummy * 0.0
+
+
 class TestTrainOneEpoch:
     """Tests for _train_one_epoch helper function."""
 
@@ -147,6 +158,71 @@ class TestTrainOneEpoch:
         assert total == 32
         assert running_loss > 0
         assert 0 <= correct <= total
+        assert grad_stats is None
+
+    def test_lm_task_counts_token_accuracy(self):
+        """LM accuracy should count correct token predictions, not always zero."""
+        from esper.simic.training.helpers import _train_one_epoch
+
+        logits = torch.tensor([
+            [[10.0, 0.0, 0.0], [0.0, 10.0, 0.0]],
+            [[0.0, 0.0, 10.0], [10.0, 0.0, 0.0]],
+        ])
+        targets = torch.tensor([
+            [0, 1],
+            [2, 0],
+        ])
+        dataloader = DataLoader(TensorDataset(logits, targets), batch_size=1)
+        model = _LogitReplayModel()
+        criterion = nn.CrossEntropyLoss()
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.0)
+
+        _running_loss, correct, total, grad_stats = _train_one_epoch(
+            model=model,
+            trainloader=dataloader,
+            criterion=criterion,
+            host_optimizer=optimizer,
+            seed_optimizer=None,
+            device="cpu",
+            task_type="lm",
+        )
+
+        assert total == 4
+        assert correct == 4
+        assert grad_stats is None
+
+    def test_loss_accumulation_is_sample_weighted_for_uneven_batches(self):
+        """Returned loss should be the summed per-sample loss, not mean-of-means."""
+        from esper.simic.training.helpers import _train_one_epoch
+
+        logits = torch.tensor([
+            [0.0, 0.0],
+            [0.0, 0.0],
+            [0.0, 1.3862944],
+        ])
+        targets = torch.tensor([0, 0, 0])
+        dataloader = DataLoader(TensorDataset(logits, targets), batch_size=2)
+        model = _LogitReplayModel()
+        criterion = nn.CrossEntropyLoss()
+        optimizer = torch.optim.SGD(model.parameters(), lr=0.0)
+
+        running_loss, _correct, total, grad_stats = _train_one_epoch(
+            model=model,
+            trainloader=dataloader,
+            criterion=criterion,
+            host_optimizer=optimizer,
+            seed_optimizer=None,
+            device="cpu",
+            task_type="classification",
+        )
+
+        expected_loss_sum = (
+            criterion(logits[:2], targets[:2]).item() * 2
+            + criterion(logits[2:], targets[2:]).item()
+        )
+        assert total == 3
+        assert running_loss == pytest.approx(expected_loss_sum)
+        assert running_loss / total == pytest.approx(expected_loss_sum / 3)
         assert grad_stats is None
 
     def test_empty_dataloader(self):


### PR DESCRIPTION
## Summary
- count token-level LM accuracy in _train_one_epoch instead of reporting zero
- accumulate helper training losses as loss * sample_or_token_count and divide by total count
- apply the same sample-weighted loss semantics to heuristic train/validation loops

## Filigree
Closes esper-lite-c93dea
Closes esper-lite-4997f7

## Verification
- PYTHONPATH=src uv run pytest tests/simic/test_training_helper.py -q
- PYTHONPATH=src uv run pytest tests/simic/test_training_helper.py tests/simic/test_heuristic_telemetry.py tests/simic/training/test_heuristic_gradient_telemetry_wiring.py -q
- PYTHONPATH=src uv run pytest tests/simic/test_vectorized.py::test_loss_aggregation_divides_by_batch_count_not_sample_count -q
- PYTHONPATH=src uv run pytest tests/simic --ignore=tests/simic/test_data_opt.py --ignore=tests/simic/test_record_stream_fix.py --ignore=tests/simic/training/test_dual_ab.py -q
- uv run ruff check src/ tests/
- uv run ruff check scripts/
- uv run python scripts/lint_defensive_patterns.py
- uv run python scripts/lint_leyline_types.py
- uv run python scripts/lint_gpu_sync.py
- MYPYPATH=src uv run mypy -p esper