### PR TITLE
fix(simic): repair telemetry context contracts

### DIFF
--- a/src/esper/simic/rewards/reward_telemetry.py
+++ b/src/esper/simic/rewards/reward_telemetry.py
@@ -238,17 +238,17 @@ class RewardComponentsTelemetry:
             growth_ratio=float(data["growth_ratio"]),  # type: ignore[arg-type]
             total_reward=float(data["total_reward"]),  # type: ignore[arg-type]
             # D2: Capacity economics
-            occupancy_rent=float(data.get("occupancy_rent", 0.0)),  # type: ignore[arg-type]
-            fossilized_rent=float(data.get("fossilized_rent", 0.0)),  # type: ignore[arg-type]
-            first_germinate_bonus=float(data.get("first_germinate_bonus", 0.0)),  # type: ignore[arg-type]
-            n_active_seeds=int(data.get("n_active_seeds", 0)),  # type: ignore[arg-type]
+            occupancy_rent=float(data["occupancy_rent"]),  # type: ignore[arg-type]
+            fossilized_rent=float(data["fossilized_rent"]),  # type: ignore[arg-type]
+            first_germinate_bonus=float(data["first_germinate_bonus"]),  # type: ignore[arg-type]
+            n_active_seeds=int(data["n_active_seeds"]),  # type: ignore[arg-type]
             # D3: Anti-timing-gaming
-            timing_discount=float(data.get("timing_discount", 1.0)),  # type: ignore[arg-type]
+            timing_discount=float(data["timing_discount"]),  # type: ignore[arg-type]
             # Drip reward (BASIC_PLUS mode)
-            drip_this_epoch=float(data.get("drip_this_epoch", 0.0)),  # type: ignore[arg-type]
-            drip_immediate_bonus=float(data.get("drip_immediate_bonus", 0.0)),  # type: ignore[arg-type]
-            drip_deferred_total=float(data.get("drip_deferred_total", 0.0)),  # type: ignore[arg-type]
-            num_drip_sources=int(data.get("num_drip_sources", 0)),  # type: ignore[arg-type]
+            drip_this_epoch=float(data["drip_this_epoch"]),  # type: ignore[arg-type]
+            drip_immediate_bonus=float(data["drip_immediate_bonus"]),  # type: ignore[arg-type]
+            drip_deferred_total=float(data["drip_deferred_total"]),  # type: ignore[arg-type]
+            num_drip_sources=int(data["num_drip_sources"]),  # type: ignore[arg-type]
         )
 
 

--- a/src/esper/simic/telemetry/emitters.py
+++ b/src/esper/simic/telemetry/emitters.py
@@ -8,9 +8,9 @@ Extracted from vectorized.py to reduce file size and improve clarity.
 
 from __future__ import annotations
 
-import dataclasses
 import logging
-from typing import TYPE_CHECKING, Any, Sequence
+import dataclasses
+from typing import TYPE_CHECKING, Any, Sequence, cast
 
 import torch
 from torch import nn
@@ -91,13 +91,30 @@ class VectorizedEmitter:
     def _emit(self, event: TelemetryEvent) -> None:
         """Emit event with environment context injected.
 
-        Note: This mutates the event in-place. Callers should not reuse event objects
+        Note: This mutates the event wrapper in-place and replaces frozen typed
+        payloads with updated copies. Callers should not reuse event objects
         across multiple emitters. In practice, each emit site creates a fresh
         TelemetryEvent, so this is safe.
         """
         event.env_id = self.env_id  # type: ignore[attr-defined]
         event.device = self.device  # type: ignore[attr-defined]
         event.group_id = self.group_id
+        if event.data is not None and dataclasses.is_dataclass(event.data):
+            payload_fields = {field.name for field in dataclasses.fields(event.data)}
+            payload_updates: dict[str, int | str] = {}
+            if "env_id" in payload_fields:
+                payload_updates["env_id"] = self.env_id
+            if "device" in payload_fields:
+                payload_updates["device"] = self.device
+            if "group_id" in payload_fields:
+                payload_updates["group_id"] = self.group_id
+            if self.episode_idx is not None and "episode_idx" in payload_fields:
+                payload_updates["episode_idx"] = self.episode_idx
+            if payload_updates:
+                event.data = cast(
+                    Any,
+                    dataclasses.replace(cast(Any, event.data), **payload_updates),
+                )
         self.hub.emit(event)
 
     def emit(self, event: TelemetryEvent) -> None:

--- a/src/esper/simic/telemetry/observation_stats.py
+++ b/src/esper/simic/telemetry/observation_stats.py
@@ -123,7 +123,8 @@ def compute_observation_stats(
         obs_tensor: Raw observation tensor [batch_size, obs_dim]
         normalized_obs_tensor: Normalized+clipped tensor fed to policy [batch_size, obs_dim]
         normalizer_mean: Current running mean from normalizer (optional)
-        normalizer_var: Current running variance from normalizer (optional)
+        normalizer_var: Current running variance from normalizer (optional).
+            Compared against the normalizer's initial variance of 1.0.
         initial_normalizer_mean: Initial running mean for drift calculation (optional)
         clip: Normalizer clip value (used for saturation/clipping indicators)
 
@@ -208,13 +209,20 @@ def compute_observation_stats(
     near_clip_pct_t = (abs_norm >= (0.9 * clip)).float().mean()
     clip_pct_t = (abs_norm >= (clip - 1e-6)).float().mean()
 
-    # Normalization drift (how much the running mean has shifted)
+    # Normalization drift (how much the running mean/std has shifted)
+    drift_parts = []
     if (
         normalizer_mean is not None
         and initial_normalizer_mean is not None
         and normalizer_mean.shape == initial_normalizer_mean.shape
     ):
-        drift_t = (normalizer_mean - initial_normalizer_mean).abs().mean()
+        drift_parts.append((normalizer_mean - initial_normalizer_mean).abs().mean())
+    if normalizer_var is not None:
+        current_std = torch.sqrt(normalizer_var.clamp_min(0.0))
+        initial_std = torch.ones_like(current_std)
+        drift_parts.append((current_std - initial_std).abs().mean())
+    if drift_parts:
+        drift_t = torch.stack(drift_parts).sum()
     else:
         drift_t = torch.tensor(0.0, device=obs_tensor.device)
 

--- a/tests/simic/telemetry/test_emitters.py
+++ b/tests/simic/telemetry/test_emitters.py
@@ -8,7 +8,12 @@ import torch
 from torch import nn
 
 from esper.karn.sanctum.schema import CounterfactualConfig, CounterfactualSnapshot
-from esper.leyline import NUM_OPS, TelemetryEventType
+from esper.leyline import (
+    GovernorRollbackPayload,
+    NUM_OPS,
+    TelemetryEvent,
+    TelemetryEventType,
+)
 from esper.simic.telemetry import TelemetryConfig, TelemetryLevel
 from esper.simic.telemetry.emitters import (
     VectorizedEmitter,
@@ -137,6 +142,36 @@ class _StubEnvState:
         self.seeds_fossilized = 0
         self.action_counts = {"WAIT": 1}
         self.successful_action_counts = {"WAIT": 1}
+
+
+def test_vectorized_emitter_injects_context_into_typed_payload() -> None:
+    """VectorizedEmitter.emit updates the typed payload, not only wrapper attrs."""
+    hub = _RecordingHub()
+    emitter = VectorizedEmitter(
+        env_id=42,
+        device="cuda:0",
+        group_id="test-group",
+        hub=hub,
+    )
+    emitter.set_episode_idx(7)
+
+    emitter.emit(TelemetryEvent(
+        event_type=TelemetryEventType.GOVERNOR_ROLLBACK,
+        data=GovernorRollbackPayload(
+            env_id=-1,
+            device="cpu",
+            reason="panic",
+        ),
+    ))
+
+    assert len(hub.events) == 1
+    event = hub.events[0]
+    assert event.env_id == 42
+    assert event.device == "cuda:0"
+    assert event.group_id == "test-group"
+    assert event.data.env_id == 42
+    assert event.data.device == "cuda:0"
+    assert event.data.episode_idx == 7
 
 
 def test_emit_ppo_update_event_propagates_group_id():

--- a/tests/simic/test_reward_telemetry.py
+++ b/tests/simic/test_reward_telemetry.py
@@ -1,5 +1,7 @@
 """Tests for reward component telemetry."""
 
+import pytest
+
 
 from esper.leyline import LifecycleOp, SeedStage
 from esper.simic.rewards import RewardComponentsTelemetry
@@ -99,15 +101,13 @@ class TestRewardComponentsTelemetry:
         assert restored.timing_discount == original.timing_discount
         assert restored.timing_discount == 0.65
 
-    def test_timing_discount_default_preserved_on_missing(self):
-        """D3: Missing timing_discount in old data defaults to 1.0."""
-        # Create full telemetry, serialize, then remove timing_discount
-        # to simulate pre-D3 data that doesn't have the field
-        original = RewardComponentsTelemetry(total_reward=1.0, bounded_attribution=0.5)
-        old_data = original.to_dict()
-        del old_data["timing_discount"]  # Simulate pre-D3 data
+    def test_from_dict_requires_d2_d3_and_drip_fields(self):
+        """Missing current reward component fields should fail loudly."""
+        data = RewardComponentsTelemetry(
+            total_reward=1.0,
+            bounded_attribution=0.5,
+        ).to_dict()
+        del data["timing_discount"]
 
-        restored = RewardComponentsTelemetry.from_dict(old_data)
-
-        # Should default to 1.0 (no discount)
-        assert restored.timing_discount == 1.0
+        with pytest.raises(KeyError, match="timing_discount"):
+            RewardComponentsTelemetry.from_dict(data)

--- a/tests/telemetry/test_environment_metrics.py
+++ b/tests/telemetry/test_environment_metrics.py
@@ -16,6 +16,7 @@ from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
+import torch
 
 from esper.karn.sanctum.aggregator import SanctumAggregator
 from esper.karn.sanctum.schema import (
@@ -27,8 +28,13 @@ from esper.leyline import (
     BatchEpochCompletedPayload,
     EpochCompletedPayload,
     EpisodeOutcomePayload,
+    OBS_V3_BASE_FEATURE_SIZE,
+    OBS_V3_SLOT_FEATURE_SIZE,
 )
-from esper.simic.telemetry.observation_stats import ObservationStatsTelemetry
+from esper.simic.telemetry.observation_stats import (
+    ObservationStatsTelemetry,
+    compute_observation_stats,
+)
 
 
 # =============================================================================
@@ -304,6 +310,21 @@ class TestTELE603NormalizationDrift:
 
         snapshot = agg.get_snapshot()
         assert snapshot.observation_stats.normalization_drift == pytest.approx(1.75)
+
+    def test_normalization_drift_includes_variance_shift(self) -> None:
+        """Changing only normalizer variance must still report drift."""
+        obs_dim = OBS_V3_BASE_FEATURE_SIZE + OBS_V3_SLOT_FEATURE_SIZE
+        obs = torch.zeros((2, obs_dim))
+
+        obs_stats = compute_observation_stats(
+            obs,
+            normalized_obs_tensor=obs,
+            normalizer_mean=torch.zeros(obs_dim),
+            normalizer_var=torch.full((obs_dim,), 4.0),
+            initial_normalizer_mean=torch.zeros(obs_dim),
+        )
+
+        assert obs_stats.normalization_drift == pytest.approx(1.0)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- inject vectorized emitter context into frozen typed telemetry payloads, not only dynamic event attrs
- include normalizer variance/std movement in normalization_drift
- make RewardComponentsTelemetry.from_dict fail fast on missing D2/D3/drip fields

## Filigree
- Fixes esper-lite-0aa641
- Fixes esper-lite-2ac173
- Fixes esper-lite-d612b3

## Verification
- uv run pytest tests/simic/telemetry/test_emitters.py::test_vectorized_emitter_injects_context_into_typed_payload -q
- uv run pytest tests/telemetry/test_environment_metrics.py::TestTELE603NormalizationDrift::test_normalization_drift_includes_variance_shift -q
- uv run pytest tests/simic/test_reward_telemetry.py::TestRewardComponentsTelemetry::test_from_dict_requires_d2_d3_and_drip_fields -q
- uv run pytest tests/simic/telemetry/test_emitters.py tests/simic/test_reward_telemetry.py tests/telemetry/test_environment_metrics.py -q
- uv run python scripts/lint_defensive_patterns.py
- uv run python scripts/lint_leyline_types.py
- uv run python scripts/lint_gpu_sync.py
- uv run ruff check src/ tests/
- MYPYPATH=src uv run mypy -p esper
- uv run pytest (4678 passed, 10 skipped, 69 deselected)