### PR TITLE
fix(simic): repair training control contracts

### DIFF
--- a/src/esper/leyline/__init__.py
+++ b/src/esper/leyline/__init__.py
@@ -166,6 +166,11 @@ DEFAULT_VALUE_COEF = 1.0
 # preserving direction while preventing true explosions (>100 norm).
 DEFAULT_MAX_GRAD_NORM = 5.0
 
+# Maximum gradient norm for host/seed supervised updates in vectorized training.
+# PPO policy clipping uses DEFAULT_MAX_GRAD_NORM; training-loop clipping uses
+# this stricter value because host/seed gradients are on a different scale.
+DEFAULT_TRAINING_MAX_GRAD_NORM = 1.0
+
 # Number of PPO epochs per batch of experience.
 # More epochs = more sample efficiency, but risks overfitting.
 DEFAULT_N_PPO_EPOCHS = 10
@@ -808,6 +813,7 @@ __all__ = [
     "ADVANTAGE_STD_FLOOR",
     "DEFAULT_VALUE_COEF",
     "DEFAULT_MAX_GRAD_NORM",
+    "DEFAULT_TRAINING_MAX_GRAD_NORM",
     "DEFAULT_N_PPO_EPOCHS",
     "DEFAULT_BATCH_SIZE",
     "DEFAULT_ENTROPY_COEF",

--- a/src/esper/simic/telemetry/gradient_collector.py
+++ b/src/esper/simic/telemetry/gradient_collector.py
@@ -14,11 +14,11 @@ from typing import Iterator, TypedDict
 import torch
 import torch.nn as nn
 
-from esper.leyline import DEFAULT_MAX_GRAD_NORM
+from esper.leyline import DEFAULT_TRAINING_MAX_GRAD_NORM
 
-# H14: PPO-tuned gradient thresholds
-# These defaults are calibrated for PPO with gradient clipping at DEFAULT_MAX_GRAD_NORM (0.5).
-# Collection happens BEFORE clipping, so we detect:
+# H14: host/seed training gradient thresholds
+# These defaults are calibrated for host/seed training with gradient clipping
+# at DEFAULT_TRAINING_MAX_GRAD_NORM. Collection happens BEFORE clipping, so we detect:
 # - Vanishing: gradients too small to provide learning signal
 # - Exploding: gradients that will be heavily clipped (10x clip norm)
 #
@@ -27,7 +27,7 @@ from esper.leyline import DEFAULT_MAX_GRAD_NORM
 # - This is informative (heavy clipping) but not catastrophic
 # - True explosions (100x+) indicate numerical instability
 DEFAULT_VANISHING_THRESHOLD = 1e-7  # Very small but non-zero
-DEFAULT_EXPLODING_THRESHOLD = 10.0 * DEFAULT_MAX_GRAD_NORM  # = 5.0 with default clip
+DEFAULT_EXPLODING_THRESHOLD = 10.0 * DEFAULT_TRAINING_MAX_GRAD_NORM
 
 
 class GradientHealthStats(TypedDict):
@@ -111,7 +111,7 @@ class SeedGradientCollector:
             vanishing_threshold: Gradient norm below this is considered vanishing.
                 Default: 1e-7 (very small but non-zero).
             exploding_threshold: Gradient norm above this is considered exploding.
-                Default: 10x clip norm (5.0 with DEFAULT_MAX_GRAD_NORM=0.5).
+                Default: 10x training clip norm.
                 At this level, gradients will be scaled down 10x by clipping.
         """
         self.vanishing_threshold = vanishing_threshold

--- a/src/esper/simic/training/config.py
+++ b/src/esper/simic/training/config.py
@@ -43,6 +43,7 @@ from esper.leyline import (
     DEFAULT_CLIP_RATIO,
     DEFAULT_ENTROPY_COEF,
     DEFAULT_ENTROPY_COEF_MIN,
+    DEFAULT_TRAINING_MAX_GRAD_NORM,
 )
 from esper.simic.rewards import RewardFamily, RewardMode
 
@@ -159,8 +160,9 @@ class TrainingConfig:
 
     # === Gradient Clipping ===
     # Maximum gradient norm for host/seed training.
-    # Default 1.0 is standard for supervised training (PPO policy uses 0.5).
-    max_grad_norm: float = 1.0
+    # Default 1.0 is standard for supervised training; PPO policy clipping
+    # uses a separate default because policy gradients are on a different scale.
+    max_grad_norm: float = DEFAULT_TRAINING_MAX_GRAD_NORM
 
     def __post_init__(self) -> None:
         """Validate and set defaults.
@@ -197,8 +199,8 @@ class TrainingConfig:
     def for_cifar_baseline_stable() -> "TrainingConfig":
         """Conservative configuration for CIFAR tasks (slower, more stable PPO).
 
-        Note: lr=1e-4 was removed after max_grad_norm increased from 1.0 to 5.0.
-        The low LR was compensating for aggressive clipping; now uses default 3e-4.
+        Note: lr=1e-4 was removed after host/seed clipping was separated from
+        PPO policy clipping. The preset now uses default 3e-4.
         """
         return TrainingConfig(
             n_episodes=200,

--- a/src/esper/simic/training/handlers/prune.py
+++ b/src/esper/simic/training/handlers/prune.py
@@ -144,11 +144,13 @@ def execute_prune(
     speed_steps = ALPHA_SPEED_TO_STEPS[AlphaSpeedAction(params.alpha_speed_idx)]
     curve_action = AlphaCurveAction(params.alpha_curve_idx)
     curve = curve_action.to_curve()
+    steepness = curve_action.to_steepness()
 
     # Schedule the prune (alpha decay to 0)
     success = ctx.slot.schedule_prune(
         steps=speed_steps,
         curve=curve,
+        steepness=steepness,
         initiator="policy",
     )
 
@@ -166,6 +168,7 @@ def execute_prune(
         telemetry={
             "speed_steps": speed_steps,
             "curve": curve.name if curve else None,
+            "steepness": steepness,
             "pre_stage": ctx.seed_state.stage.name if ctx.seed_state else None,
             "seed_age_epochs": seed_info.seed_age_epochs if seed_info else 0,
         },

--- a/src/esper/simic/training/vectorized.py
+++ b/src/esper/simic/training/vectorized.py
@@ -802,6 +802,16 @@ def train_ppo_vectorized(
     ]
     batch_emitter = emitters[0]
 
+    # TUI mode (Sanctum/Overwatch) is optimized for debuggability. Disable
+    # torch.compile here to avoid TorchInductor failures that are difficult
+    # to recover from in an interactive session.
+    # Determine effective compile mode: quiet_analytics disables compilation
+    # unless force_compile is set (for testing compilation with TUI).
+    if force_compile:
+        effective_compile_mode = compile_mode
+    else:
+        effective_compile_mode = compile_mode if not quiet_analytics else "off"
+
     # Create or resume PPO agent
     if resume_path:
         checkpoint = torch.load(resume_path, map_location="cpu", weights_only=True)
@@ -809,6 +819,7 @@ def train_ppo_vectorized(
             checkpoint,
             device=device,
             expected_slot_config=slot_config,
+            compile_mode=effective_compile_mode,
         )
 
         # Restore observation normalizer state
@@ -854,16 +865,6 @@ def train_ppo_vectorized(
             )
         )
     else:
-        # TUI mode (Sanctum/Overwatch) is optimized for debuggability. Disable
-        # torch.compile here to avoid TorchInductor failures that are difficult
-        # to recover from in an interactive session.
-        # Determine effective compile mode: quiet_analytics disables compilation
-        # unless force_compile is set (for testing compilation with TUI).
-        if force_compile:
-            effective_compile_mode = compile_mode
-        else:
-            effective_compile_mode = compile_mode if not quiet_analytics else "off"
-
         # Create policy via Tamiyo factory
         # IMPORTANT: Pass actual slot_config to ensure action heads/masks align
         # with environment slot ordering (critical for non-default slot layouts)

--- a/tests/simic/test_gradient_collector.py
+++ b/tests/simic/test_gradient_collector.py
@@ -6,6 +6,7 @@ import torch
 import torch.nn as nn
 import pytest
 
+from esper.simic.training.config import TrainingConfig
 from esper.simic.telemetry import (
     SeedGradientCollector,
     materialize_grad_stats,
@@ -15,6 +16,7 @@ from esper.simic.telemetry import (
     GradientHealthMetrics,
     DualGradientStats,
 )
+from esper.simic.telemetry.gradient_collector import DEFAULT_EXPLODING_THRESHOLD
 
 
 # =============================================================================
@@ -24,6 +26,12 @@ from esper.simic.telemetry import (
 
 class TestSeedGradientCollector:
     """Tests for basic SeedGradientCollector functionality."""
+
+    def test_default_exploding_threshold_matches_training_clip_norm(self):
+        """Default telemetry threshold tracks the vectorized training clip norm."""
+        assert DEFAULT_EXPLODING_THRESHOLD == pytest.approx(
+            10.0 * TrainingConfig().max_grad_norm
+        )
 
     def test_gradient_collector_vectorized(self):
         """Verify gradient collection uses vectorized operations."""

--- a/tests/simic/test_reward_normalizer_checkpoint.py
+++ b/tests/simic/test_reward_normalizer_checkpoint.py
@@ -212,6 +212,7 @@ def test_resume_uses_single_preloaded_checkpoint_for_agent_and_metadata(
     original_get_task_spec = runtime.get_task_spec
     original_torch_load = torch.load
     load_calls = []
+    agent_load_calls = []
 
     def get_task_spec_mock(name: str):
         spec = original_get_task_spec(name)
@@ -221,6 +222,10 @@ def test_resume_uses_single_preloaded_checkpoint_for_agent_and_metadata(
     def torch_load_mock(*args, **kwargs):
         load_calls.append((args, kwargs))
         return original_torch_load(*args, **kwargs)
+
+    def load_from_checkpoint_dict_mock(*args, **kwargs):
+        agent_load_calls.append((args, kwargs))
+        return object()
 
     class StubHub:
         def add_backend(self, _backend) -> None:
@@ -245,7 +250,7 @@ def test_resume_uses_single_preloaded_checkpoint_for_agent_and_metadata(
     monkeypatch.setattr(
         vectorized.PPOAgent,
         "load_from_checkpoint_dict",
-        lambda *args, **kwargs: object(),
+        load_from_checkpoint_dict_mock,
     )
 
     checkpoint_path = tmp_path / "checkpoint.pt"
@@ -279,6 +284,84 @@ def test_resume_uses_single_preloaded_checkpoint_for_agent_and_metadata(
     assert len(load_calls) == 1
     assert load_calls[0][0][0] == str(checkpoint_path)
     assert load_calls[0][1]["map_location"] == "cpu"
+    assert len(agent_load_calls) == 1
+    assert agent_load_calls[0][1]["compile_mode"] == "off"
+
+
+def test_resume_force_compile_overrides_quiet_analytics(monkeypatch, tmp_path):
+    import esper.runtime as runtime
+    import esper.simic.training.vectorized as vectorized
+    from esper.leyline import TelemetryEventType
+
+    original_get_task_spec = runtime.get_task_spec
+    agent_load_calls = []
+
+    def get_task_spec_mock(name: str):
+        spec = original_get_task_spec(name)
+        spec.dataloader_defaults["mock"] = True
+        return spec
+
+    def load_from_checkpoint_dict_mock(*args, **kwargs):
+        agent_load_calls.append((args, kwargs))
+        return object()
+
+    class StubHub:
+        def add_backend(self, _backend) -> None:
+            return None
+
+        def emit(self, event) -> None:
+            if event.event_type == TelemetryEventType.CHECKPOINT_LOADED:
+                raise _StopAfterCheckpointLoaded()
+            return None
+
+    class StubSharedBatchIterator:
+        def __init__(self, *args, **kwargs):
+            return None
+
+        def __len__(self) -> int:
+            return 0
+
+    monkeypatch.setattr(runtime, "get_task_spec", get_task_spec_mock)
+    monkeypatch.setattr(vectorized, "get_hub", lambda: StubHub())
+    monkeypatch.setattr(vectorized, "SharedBatchIterator", StubSharedBatchIterator)
+    monkeypatch.setattr(
+        vectorized.PPOAgent,
+        "load_from_checkpoint_dict",
+        load_from_checkpoint_dict_mock,
+    )
+
+    checkpoint_path = tmp_path / "checkpoint.pt"
+    torch.save(
+        {
+            "metadata": {
+                "n_episodes": 0,
+                "batches_completed": 0,
+                "n_envs": 1,
+            }
+        },
+        checkpoint_path,
+    )
+
+    with pytest.raises(_StopAfterCheckpointLoaded):
+        vectorized.train_ppo_vectorized(
+            n_episodes=1,
+            n_envs=1,
+            max_epochs=1,
+            chunk_length=1,
+            device="cpu",
+            devices=["cpu"],
+            task="cifar_baseline",
+            slots=["r0c1"],
+            use_telemetry=False,
+            num_workers=0,
+            resume_path=str(checkpoint_path),
+            quiet_analytics=True,
+            force_compile=True,
+            compile_mode="reduce-overhead",
+        )
+
+    assert len(agent_load_calls) == 1
+    assert agent_load_calls[0][1]["compile_mode"] == "reduce-overhead"
 
 
 def test_resume_rejects_checkpoint_slot_ids_that_do_not_match_runtime_slots(

--- a/tests/simic/training/handlers/test_prune_handler.py
+++ b/tests/simic/training/handlers/test_prune_handler.py
@@ -1,0 +1,74 @@
+"""Unit tests for the PRUNE operation handler."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from esper.leyline import (
+    MIN_PRUNE_AGE,
+    AlphaCurveAction,
+    AlphaMode,
+    AlphaSpeedAction,
+    SeedStage,
+)
+from esper.simic.rewards import SeedInfo
+from esper.simic.training.handlers import HandlerContext, PruneParams, execute_prune
+from esper.simic.training.parallel_env_state import ParallelEnvState
+
+
+@pytest.fixture
+def prunable_context() -> HandlerContext:
+    """Create a HandlerContext with a training seed eligible for pruning."""
+    env_state = MagicMock(spec=ParallelEnvState)
+    env_state.prune_count = 0
+
+    seed_state = MagicMock()
+    seed_state.stage = SeedStage.TRAINING
+    seed_state.alpha_controller.alpha_mode = AlphaMode.HOLD
+    seed_state.can_transition_to.return_value = True
+
+    slot = MagicMock()
+    slot.schedule_prune.return_value = True
+
+    return HandlerContext(
+        env_idx=0,
+        slot_id="r0c0",
+        env_state=env_state,
+        model=MagicMock(),
+        slot=slot,
+        seed_state=seed_state,
+        epoch=5,
+        max_epochs=150,
+        episodes_completed=0,
+    )
+
+
+def test_execute_prune_passes_sigmoid_steepness(
+    prunable_context: HandlerContext,
+) -> None:
+    """Policy-selected sigmoid variants must reach the slot schedule."""
+    seed_info = SeedInfo(
+        stage=SeedStage.TRAINING.value,
+        improvement_since_stage_start=0.0,
+        total_improvement=0.0,
+        epochs_in_stage=1,
+        seed_age_epochs=MIN_PRUNE_AGE,
+    )
+    params = PruneParams(
+        alpha_speed_idx=AlphaSpeedAction.FAST.value,
+        alpha_curve_idx=AlphaCurveAction.SIGMOID_GENTLE.value,
+    )
+
+    result = execute_prune(prunable_context, params, seed_info)
+
+    assert result.success is True
+    prunable_context.slot.schedule_prune.assert_called_once_with(
+        steps=3,
+        curve=AlphaCurveAction.SIGMOID_GENTLE.to_curve(),
+        steepness=AlphaCurveAction.SIGMOID_GENTLE.to_steepness(),
+        initiator="policy",
+    )
+    assert result.telemetry["steepness"] == pytest.approx(6.0)
+    assert prunable_context.env_state.prune_count == 1


### PR DESCRIPTION
## Summary
- apply the effective torch.compile mode to resumed PPO agents so quiet_analytics and force_compile behave the same on resume and fresh starts
- split the host/seed training gradient clip default from the PPO policy clip default and calibrate gradient exploding telemetry against the training clip norm
- pass policy-selected prune sigmoid steepness through to schedule_prune and expose it in prune telemetry

## Verification
- uv run pytest tests/simic/test_reward_normalizer_checkpoint.py -q
- uv run pytest tests/simic/test_gradient_collector.py tests/simic/training/test_gradient_clipping.py -q
- uv run pytest tests/simic/training/handlers/test_prune_handler.py -q
- uv run python scripts/lint_defensive_patterns.py
- uv run python scripts/lint_leyline_types.py
- uv run python scripts/lint_gpu_sync.py
- uv run ruff check src/ tests/
- MYPYPATH=src uv run mypy -p esper
- uv run pytest (4681 passed, 10 skipped, 69 deselected)

Fixes esper-lite-afaf1a, esper-lite-df2f30, esper-lite-6cc6b6