### PR TITLE
fix(simic): tighten PPO contract metrics

### DIFF
--- a/docs/coord/PLAN_TRACKER.md
+++ b/docs/coord/PLAN_TRACKER.md
@@ -1,6 +1,6 @@
 # Esper Plan Tracker
 
-**Last Updated:** 2026-06-12 (baseline green; P1 stability batch 1 locally complete)
+**Last Updated:** 2026-06-13 (baseline green; P1 follow-up PRs merged; first P2 contract batch locally verified)
 **Purpose:** Rack-and-stack all plans and concepts for prioritization and dependency tracking.
 
 ---
@@ -15,9 +15,11 @@ main CI passed. The active plan is
 `docs/plans/ready/2026-06-12-green-state-recovery.md`.
 
 Current operating rule: drain high-risk correctness bugs before feature work.
-Recovery PR #72 is merged. P1 stability batch 1 is locally complete and ready
-for PR verification. Security/dependency PRs remain next unless a fresh critical
-correctness bug appears.
+Recovery PR #72 is merged. Follow-up PRs #78 and #79 merged telemetry and
+training-control correctness fixes with passing CI. The first P2 contract
+batch now has local fixes and passing static/full-test/Wardline gates on
+`codex/p2-steady-state-drain`; Filigree tracker closure is pending a writable
+tracker surface because the UV tool install was removed.
 
 ### Post-Hiatus Audit (2026-02-21)
 
@@ -31,8 +33,8 @@ op twice independently — once in `forward()` for value computation, once in `g
 the stored action. These ops frequently diverge, corrupting advantage estimates. Blocks Phase 7.
 
 ### Current Focus Areas
-1. **Green State Recovery** - 🔴 CRITICAL! Baseline green; post-baseline P1 stability drain active
-2. **P1 Stability Batch 1** - ✅ Locally complete; six high-risk PPO/telemetry correctness bugs closed
+1. **Green State Recovery** - 🔴 CRITICAL! Baseline green; first P2 contract batch locally verified
+2. **P1 Stability Batch 1** - ✅ Completed and merged; six high-risk PPO/telemetry correctness bugs closed
 3. **P0 Filigree Bug Drain** - ✅ Initial six P0s fixed and closed
 4. **Op/Value Mismatch** - 🔴 CRITICAL! Fix double-sampling in factored_lstm.py
 5. **Reward Efficiency Experiment** - Infrastructure complete, experiment never run
@@ -68,8 +70,8 @@ the stored action. These ops frequently diverge, corrupting advantage estimates.
 
 | ID | Title | Type | Urgency | Complexity | Risk | Status |
 |----|-------|------|---------|------------|------|--------|
-| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: final gates and PR disposition after green baseline + P0 fixes |
-| p1-stability-batch-1 | PPO/Telemetry Stability Batch 1 | ready-for-pr | 🔴 critical | M | high | Locally complete: six bugs closed, broad gates passed |
+| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: first P2 contract batch locally verified; PR/tracker closure pending |
+| p1-stability-batch-1 | PPO/Telemetry Stability Batch 1 | completed-batch | 🔴 critical | M | high | Completed and merged; six bugs closed, broad gates passed |
 | filigree-p0-drain | Critical Filigree P0 Bug Drain | completed-batch | 🔴 critical | L | high | Initial six P0s fixed, verified, and closed |
 | op-value-mismatch | Q(s,op) Double-Sampling Bug | investigation | 🔴 critical | M | high | Diagnosed 2025-12-31, blocks Phase 7. See `docs/bugs/investigations/` |
 

--- a/docs/plans/ready/2026-06-12-green-state-recovery.md
+++ b/docs/plans/ready/2026-06-12-green-state-recovery.md
@@ -6,7 +6,7 @@ id: green-state-recovery-2026-06-12
 title: Green State Recovery Program
 type: in-progress
 created: 2026-06-12
-updated: 2026-06-12
+updated: 2026-06-13
 owner: Codex
 
 urgency: critical
@@ -29,12 +29,13 @@ blocks:
 status_notes: >
   PR #52 was made green, accepted, and merged as the new baseline on 2026-06-12.
   Main CI passed on merge commit cdff9c43. Recovery PR #72 landed the initial
-  P0 Filigree bug drain and project Filigree install removal at merge commit
-  514e04a6. P1 stability batch 1 is locally complete: six high-priority
-  PPO/telemetry bugs are closed, focused tests passed, broad static gates
-  passed, and the broad Simic sweep passed with known local CUDA/data-fetch
-  exclusions.
-percent_complete: 94
+  P0 Filigree bug drain and project Filigree install removal. Follow-up PRs
+  #78 and #79 merged telemetry and training-control correctness fixes. The
+  repository is green on CI, but not yet steady. The first P2 contract batch
+  is locally fixed and verified against checkpoint, PPO metrics, type, lint,
+  full pytest, and Wardline gates. Filigree tracker closure is pending an
+  available update surface after removing the UV tool install.
+percent_complete: 80
 
 reviewed_by:
   - reviewer: python-engineering
@@ -83,6 +84,46 @@ Return the project to a steady state:
   - `property-tests`
   - `unit-and-integration-tests`
   - `e2e-smoke-tests`
+- PR #78 (`codex/p1-telemetry-correctness`) was merged into `main` on
+  2026-06-12 at merge commit `9cd6284cdcbe266ddaefec3925e7620222d16960`.
+- PR #78 verification run `27418134962` passed:
+  - `lint`
+  - `typecheck`
+  - `property-tests`
+  - `unit-and-integration-tests`
+  - `e2e-smoke-tests`
+- PR #79 (`codex/p1-training-correctness`) was merged into `main` on
+  2026-06-12 at merge commit `e66517dee8abeabb8e6855b09d0efee1915a68e3`.
+- PR #79 verification run `27420206496` passed:
+  - `lint`
+  - `typecheck`
+  - `property-tests`
+  - `unit-and-integration-tests`
+  - `e2e-smoke-tests`
+- Local full-suite verification after PR #79: `uv run pytest` passed
+  `4681 passed, 10 skipped, 69 deselected`.
+- Local P2 contract batch verification on 2026-06-13 passed:
+  - `uv run pytest tests/simic/test_ppo_checkpoint.py tests/simic/agent/test_ppo_finiteness_gate.py tests/simic/agent/test_ppo_metrics_contract.py -q`
+  - `uv run python scripts/lint_defensive_patterns.py`
+  - `uv run python scripts/lint_leyline_types.py`
+  - `uv run python scripts/lint_gpu_sync.py`
+  - `uv run ruff check src/ tests/`
+  - `MYPYPATH=src uv run mypy -p esper`
+  - `uv run pytest` (`4686 passed, 10 skipped, 69 deselected`)
+  - `wardline scan . --fail-on ERROR` (`0 active`)
+- Filigree was removed from the UV tool install on 2026-06-13:
+  `uv tool uninstall filigree` removed `filigree`, `filigree-dashboard`,
+  `filigree-mcp`, `filigree-scanner-claude`, and `filigree-scanner-codex`.
+  `uv tool list` now retains only Legis, Loomweave, Loomweave plugins, and
+  Wardline from the local standard tooling set.
+- Filigree on 2026-06-13 reports `22 ready`, `0 blocked`, and `0 wip`.
+  The ready queue includes 19 P2 bugs and 2 P3 bugs plus the future release
+  placeholder.
+- Loomweave MCP is reachable, but the active MCP server still reports no
+  `.weft/loomweave/loomweave.db`. The index exists in `/home/john/esper-lite`
+  and is absent in the clean recovery worktree, so code archaeology must fall
+  back to shell search until the server is reconnected or the index is copied
+  into the worktree.
 - The working tree also contains unrelated dirty skill/config files. These must not be reverted or silently included in the PR #52 stabilization commit.
 
 ## Definition Of Green
@@ -106,6 +147,10 @@ The project is steady only when:
 - `main` contains the selected baseline.
 - `main` or the merge commit has a passing required CI run.
 - Critical P0 issues are fixed, closed, or explicitly reclassified with evidence.
+- P1 correctness issues found during recovery are fixed, closed, or explicitly
+  reclassified with evidence.
+- Remaining P2/P3 issues are either fixed and closed, bundled into a documented
+  follow-up release plan, or intentionally reclassified with evidence.
 - Open PRs have an explicit disposition.
 - No known task-scope defects are hidden as scratch observations.
 
@@ -301,6 +346,61 @@ The excluded files are CUDA/data-dependent smoke tests:
 - `tests/simic/test_record_stream_fix.py`
 - `tests/simic/training/test_dual_ab.py`
 
+### I. Drain P1/P2 Contract Bugs
+
+Owner: primary agent with specialist subagents as needed.
+
+Scope:
+
+- Continue from the current Filigree ready queue after PR #79.
+- Prefer coherent batches that share verification gates and code ownership:
+  checkpoint/resume contracts, telemetry schema contracts, PPO/tensor
+  performance contracts, and action-handler parameter contracts.
+- Keep each batch small enough to review and merge independently.
+- Do not mix dependency-security work with training-correctness fixes unless a
+  dependency update is directly required by a fix.
+
+Acceptance:
+
+- Use `filigree start-work <id> --advance --assignee Codex` before editing.
+- Every claimed issue has a focused regression test or an explicit stale-issue
+  closure comment backed by current source/tests.
+- Full local static gates pass for any batch that changes shared contracts:
+
+```bash
+uv run python scripts/lint_defensive_patterns.py
+uv run python scripts/lint_leyline_types.py
+uv run python scripts/lint_gpu_sync.py
+uv run ruff check src/ tests/
+MYPYPATH=src uv run mypy -p esper
+uv run pytest
+```
+
+- GitHub PR checks pass before merge.
+- Filigree issues move `fixing -> verifying -> closed` only after merged code
+  or explicit current-state verification.
+
+Current queue snapshot, 2026-06-13:
+
+- P2 ready bugs: 19
+- P3 ready bugs: 2
+- Blocked: 0
+- WIP: 0
+
+Current local batch:
+
+1. `esper-lite-aa2a27` checkpoint load fallback/legacy filtering.
+2. `esper-lite-dcb298` PPO update metrics TypedDict drift.
+3. `esper-lite-860e79` finiteness gate failure list type preservation.
+
+These all affect typed training/checkpoint/telemetry contracts and should be
+verified together with checkpoint, PPO metric, defensive-pattern, type, and
+full default pytest gates.
+
+Status: fixed and locally verified on branch `codex/p2-steady-state-drain`.
+Tracker closure remains pending because the Filigree UV tool install was
+removed and no writable Filigree MCP tool is currently exposed in this session.
+
 ## Execution Log
 
 - 2026-06-12: Program opened. PR #52 identified as critical path. Sidecar subagents dispatched for `origin/main` baseline verification and open PR classification.
@@ -309,3 +409,13 @@ The excluded files are CUDA/data-dependent smoke tests:
 - 2026-06-12: Main post-merge Test Suite `27411344212` passed.
 - 2026-06-12: Closed initial six P0 bugs: `esper-lite-41841f`, `esper-lite-7078b7`, `esper-lite-52ee59`, `esper-lite-b765c2`, `esper-lite-30e631`, and `esper-lite-102ff8`.
 - 2026-06-12: Final local gates passed except CUDA/data-dependent smoke files blocked by local SSL dataset fetch.
+- 2026-06-12: PR #78 merged telemetry correctness fixes and closed
+  `esper-lite-0aa641`, `esper-lite-2ac173`, and `esper-lite-d612b3`.
+- 2026-06-12: PR #79 merged training-control correctness fixes and closed
+  `esper-lite-afaf1a`, `esper-lite-df2f30`, and `esper-lite-6cc6b6`.
+- 2026-06-13: Recovery plan refreshed for the remaining P2/P3 contract drain.
+- 2026-06-13: Removed Filigree from the UV tool install; Legis, Loomweave, and
+  Wardline remain installed as UV tools.
+- 2026-06-13: Locally fixed and verified P2 contract batch
+  `esper-lite-aa2a27`, `esper-lite-dcb298`, and `esper-lite-860e79`; tracker
+  closure is pending a writable Filigree surface.

--- a/leyline_boundaries.yaml
+++ b/leyline_boundaries.yaml
@@ -249,10 +249,6 @@ allow_hits:
     owner: "john"
     reason: "Rollout buffer implementation, simic-internal"
 
-  - key: "src/esper/simic/agent/types.py:typeddict:GradientStats"
-    owner: "john"
-    reason: "PPO update gradient stats schema"
-
   - key: "src/esper/simic/agent/types.py:typeddict:HeadGradientNorms"
     owner: "john"
     reason: "Per-head gradient norms schema"

--- a/src/esper/simic/agent/__init__.py
+++ b/src/esper/simic/agent/__init__.py
@@ -21,7 +21,6 @@ from .ppo_agent import (
 )
 
 from .types import (
-    GradientStats,
     PPOUpdateMetrics,
     HeadLogProbs,
     HeadEntropies,
@@ -38,7 +37,6 @@ __all__ = [
     "CHECKPOINT_VERSION",
     "PPOAgent",
     # Types
-    "GradientStats",
     "PPOUpdateMetrics",
     "HeadLogProbs",
     "HeadEntropies",

--- a/src/esper/simic/agent/ppo_agent.py
+++ b/src/esper/simic/agent/ppo_agent.py
@@ -1420,6 +1420,7 @@ class PPOAgent:
             architecture = checkpoint['architecture']
             config = checkpoint['config']
             train_steps = checkpoint['train_steps']
+            aux_training_step = checkpoint['aux_training_step']
         except KeyError as e:
             raise RuntimeError(
                 f"Incompatible checkpoint format: missing required field {e}. "
@@ -1436,9 +1437,6 @@ class PPOAgent:
                 f"This checkpoint was saved with an older version (before v2). "
                 f"Please retrain the model to create a compatible checkpoint."
             ) from e
-
-        # Extract aux_training_step (defaults to 0 for new field - not backwards compat, just sensible default)
-        aux_training_step = checkpoint.get('aux_training_step', 0)
 
         # M6: Free checkpoint memory immediately after extracting needed data.
         # Checkpoint holds a full copy of all model weights; waiting for GC to
@@ -1514,10 +1512,13 @@ class PPOAgent:
         )
 
         # === Create agent with restored config ===
-        # Remove config params that are now part of PolicyBundle or removed
-        # P2 FIX: Also filter 'n_epochs' - removed dead parameter (old checkpoints may have it)
-        agent_config = {k: v for k, v in config.items()
-                       if k not in ('lstm_hidden_dim', 'n_epochs')}
+        if "n_epochs" in config:
+            raise RuntimeError(
+                "Incompatible checkpoint: config.n_epochs is no longer supported. "
+                "Please retrain the model to create a compatible checkpoint."
+            )
+        # Remove config params that are now part of PolicyBundle.
+        agent_config = {k: v for k, v in config.items() if k != 'lstm_hidden_dim'}
         agent = cls(
             policy=policy,
             slot_config=slot_config,

--- a/src/esper/simic/agent/ppo_metrics.py
+++ b/src/esper/simic/agent/ppo_metrics.py
@@ -75,6 +75,9 @@ class PPOUpdateMetricsBuilder:
         aggregated_result["finiteness_gate_skip_count"] = len(self.finiteness_failures)
 
         for k, v in self.metrics.items():
+            if k == "finiteness_gate_failures":
+                aggregated_result[k] = v  # type: ignore[literal-required]
+                continue
             if not v:
                 if k in ("op_q_values", "op_valid_mask"):
                     raise ValueError(f"Missing required PPO metric '{k}'.")
@@ -88,9 +91,6 @@ class PPOUpdateMetricsBuilder:
             if k == "op_valid_mask":
                 op_mask = v[0]
                 aggregated_result[k] = tuple(bool(x) for x in op_mask.tolist())  # type: ignore[literal-required]
-                continue
-            if k == "finiteness_gate_failures":
-                aggregated_result[k] = v  # type: ignore[literal-required]
                 continue
             if k == "early_stop_epoch":
                 aggregated_result[k] = int(v[0].item())  # type: ignore[literal-required]

--- a/src/esper/simic/agent/types.py
+++ b/src/esper/simic/agent/types.py
@@ -10,14 +10,6 @@ from typing import Any, TypedDict
 import torch
 
 
-class GradientStats(TypedDict):
-    """Gradient statistics from PPO update."""
-
-    grad_norm: float
-    max_grad: float
-    min_grad: float
-
-
 class HeadGradientNorms(TypedDict):
     """Per-head gradient norms from factored policy (P4-6).
 
@@ -68,11 +60,11 @@ class PPOUpdateMetrics(TypedDict, total=False):
     # Scalar metrics (aggregated across epochs)
     policy_loss: float
     value_loss: float
-    entropy_loss: float
     entropy_floor_penalty: float  # Per-head entropy floor penalty (for calibration debugging)
-    total_loss: float
     approx_kl: float
     clip_fraction: float
+    clip_fraction_positive: float
+    clip_fraction_negative: float
     explained_variance: float
     entropy: float
     ratio_mean: float
@@ -81,6 +73,21 @@ class PPOUpdateMetrics(TypedDict, total=False):
     ratio_std: float  # Standard deviation of importance sampling ratio
     early_stop_epoch: int | None  # None when early stopping didn't occur
     pre_clip_grad_norm: float  # Gradient norm before clipping (for telemetry)
+    gradient_cv: float  # Coefficient of variation across per-head gradient norms
+    value_mean: float
+    value_std: float
+    value_min: float
+    value_max: float
+    return_mean: float
+    return_std: float
+    value_target_scale: float
+    pre_norm_advantage_mean: float
+    pre_norm_advantage_std: float  # Raw std before normalization (for diagnostics)
+    advantage_mean: float
+    advantage_std: float
+    advantage_skewness: float
+    advantage_kurtosis: float
+    advantage_positive_ratio: float
     # Value function metrics (TELE-220 to TELE-228)
     v_return_correlation: float
     td_error_mean: float
@@ -112,7 +119,6 @@ class PPOUpdateMetrics(TypedDict, total=False):
     head_op_ratio_max: float
     joint_ratio_max: float
     # Structured metrics
-    gradient_stats: GradientStats | None
     head_entropies: dict[str, list[float]]  # Per-head, per-epoch
     conditional_head_entropies: dict[str, list[float]]  # Entropy when head is causally relevant
     head_grad_norms: dict[str, list[float]]  # Per-head, per-epoch
@@ -126,8 +132,6 @@ class PPOUpdateMetrics(TypedDict, total=False):
     head_nan_detected: dict[str, bool]
     head_inf_detected: dict[str, bool]
     # LSTM hidden state health (TELE-340)
-    lstm_h_l2_total: float | None
-    lstm_c_l2_total: float | None
     lstm_h_rms: float | None
     lstm_c_rms: float | None
     lstm_h_env_rms_mean: float | None
@@ -142,9 +146,8 @@ class PPOUpdateMetrics(TypedDict, total=False):
     # Track forced WAIT steps to understand PPO stability under slot saturation
     forced_step_ratio: float  # Fraction of timesteps with forced decisions (no agency)
     usable_actor_timesteps: int  # Count of timesteps where agent had real choice
-    decision_density: float  # Fraction with agency (1 - forced_step_ratio), higher = healthier
     advantage_std_floored: bool  # True if advantage std was clamped to floor (degenerate batch)
-    pre_norm_advantage_std: float  # Raw std before normalization (for diagnostics)
+    d5_pre_norm_advantage_std: float  # Raw std before normalization for slot saturation diagnostics
 
     # Auxiliary contribution supervision metrics (Phase 4.1)
     # DRL Expert: Monitor for prediction collapse and quality
@@ -195,7 +198,6 @@ class ActionDict(TypedDict):
 
 
 __all__ = [
-    "GradientStats",
     "HeadGradientNorms",
     "FinitenessGateFailure",
     "PPOUpdateMetrics",

--- a/tests/simic/agent/test_ppo_finiteness_gate.py
+++ b/tests/simic/agent/test_ppo_finiteness_gate.py
@@ -17,6 +17,19 @@ from esper.leyline import NUM_OPS
 from esper.simic.agent.ppo_metrics import PPOUpdateMetricsBuilder
 
 
+VALUE_FUNC_NAN_METRICS = {
+    "v_return_correlation": float("nan"),
+    "td_error_mean": float("nan"),
+    "td_error_std": float("nan"),
+    "bellman_error": float("nan"),
+    "return_p10": float("nan"),
+    "return_p50": float("nan"),
+    "return_p90": float("nan"),
+    "return_variance": float("nan"),
+    "return_skewness": float("nan"),
+}
+
+
 class TestFinitenessGateAggregation:
     """Test the aggregation logic when all epochs skip."""
 
@@ -41,17 +54,7 @@ class TestFinitenessGateAggregation:
             log_prob_max_across_epochs=torch.tensor(float("-inf")),
             head_ratio_max_across_epochs={},
             joint_ratio_max_across_epochs=torch.tensor(float("-inf")),
-            value_func_metrics={
-                "v_return_correlation": float("nan"),
-                "td_error_mean": float("nan"),
-                "td_error_std": float("nan"),
-                "bellman_error": float("nan"),
-                "return_p10": float("nan"),
-                "return_p50": float("nan"),
-                "return_p90": float("nan"),
-                "return_variance": float("nan"),
-                "return_skewness": float("nan"),
-            },
+            value_func_metrics=VALUE_FUNC_NAN_METRICS,
             cuda_memory_metrics={},
             head_names=(),
         )
@@ -63,6 +66,36 @@ class TestFinitenessGateAggregation:
         assert not any(result["op_valid_mask"])
         assert math.isnan(result["q_variance"])
         assert math.isnan(result["q_spread"])
+
+    def test_empty_finiteness_gate_failures_stays_list_when_update_succeeds(self):
+        """Successful updates should preserve an empty failure list as [] rather than 0.0."""
+        metrics: dict[str, list[Any]] = defaultdict(list)
+        metrics["ratio_max"].append(torch.tensor(1.1))
+        metrics["ratio_min"].append(torch.tensor(0.9))
+        metrics["finiteness_gate_failures"] = []
+
+        builder = PPOUpdateMetricsBuilder(
+            metrics=metrics,
+            finiteness_failures=metrics["finiteness_gate_failures"],
+            epochs_completed=1,
+            head_entropies={},
+            conditional_head_entropies={},
+            head_grad_norms={},
+            head_nan_detected={},
+            head_inf_detected={},
+            lstm_health_history=defaultdict(list),
+            log_prob_min_across_epochs=torch.tensor(float("inf")),
+            log_prob_max_across_epochs=torch.tensor(float("-inf")),
+            head_ratio_max_across_epochs={},
+            joint_ratio_max_across_epochs=torch.tensor(float("-inf")),
+            value_func_metrics=VALUE_FUNC_NAN_METRICS,
+            cuda_memory_metrics={},
+            head_names=(),
+        )
+
+        result = builder.finalize().metrics
+
+        assert result["finiteness_gate_failures"] == []
 
     def test_all_epochs_skipped_returns_explicit_signal(self):
         """When all epochs hit finiteness gate, ppo_update_performed=False."""

--- a/tests/simic/agent/test_ppo_metrics_contract.py
+++ b/tests/simic/agent/test_ppo_metrics_contract.py
@@ -1,0 +1,46 @@
+"""Contract tests for PPO update metric type declarations."""
+
+from esper.simic.agent.types import PPOUpdateMetrics
+
+
+def test_ppo_update_metrics_declares_emitted_agent_keys():
+    """PPOUpdateMetrics should list keys emitted by PPOAgent.update()."""
+    annotations = PPOUpdateMetrics.__annotations__
+
+    emitted_keys = {
+        "advantage_kurtosis",
+        "advantage_mean",
+        "advantage_positive_ratio",
+        "advantage_skewness",
+        "advantage_std",
+        "clip_fraction_negative",
+        "clip_fraction_positive",
+        "d5_pre_norm_advantage_std",
+        "gradient_cv",
+        "pre_norm_advantage_mean",
+        "return_mean",
+        "return_std",
+        "value_max",
+        "value_mean",
+        "value_min",
+        "value_std",
+        "value_target_scale",
+    }
+
+    assert emitted_keys <= annotations.keys()
+
+
+def test_ppo_update_metrics_excludes_stale_agent_keys():
+    """PPOUpdateMetrics should not advertise keys the agent no longer emits."""
+    annotations = PPOUpdateMetrics.__annotations__
+
+    stale_keys = {
+        "decision_density",
+        "entropy_loss",
+        "gradient_stats",
+        "lstm_c_l2_total",
+        "lstm_h_l2_total",
+        "total_loss",
+    }
+
+    assert annotations.keys().isdisjoint(stale_keys)

--- a/tests/simic/test_ppo_checkpoint.py
+++ b/tests/simic/test_ppo_checkpoint.py
@@ -222,6 +222,46 @@ class TestPPOCheckpointNoBackwardsCompatibility:
         with pytest.raises(RuntimeError, match="Checkpoint version mismatch"):
             PPOAgent.load(tmp_path / "wrong_version.pt", device="cpu")
 
+    def test_missing_aux_training_step_fails_fast(self, tmp_path: Path):
+        """Checkpoints must include aux_training_step rather than defaulting to zero."""
+        slot_config = SlotConfig.default()
+        policy = create_policy(
+            policy_type="lstm",
+            state_dim=get_feature_size(slot_config),
+            slot_config=slot_config,
+            device="cpu",
+            compile_mode="off",
+        )
+        agent = PPOAgent(policy=policy, device="cpu")
+        agent.save(tmp_path / "agent.pt")
+
+        checkpoint = torch.load(tmp_path / "agent.pt", weights_only=False)
+        del checkpoint["aux_training_step"]
+        torch.save(checkpoint, tmp_path / "missing_aux_step.pt")
+
+        with pytest.raises(RuntimeError, match="aux_training_step"):
+            PPOAgent.load(tmp_path / "missing_aux_step.pt", device="cpu")
+
+    def test_checkpoint_with_removed_n_epochs_fails_fast(self, tmp_path: Path):
+        """Old checkpoint config containing removed n_epochs is incompatible."""
+        slot_config = SlotConfig.default()
+        policy = create_policy(
+            policy_type="lstm",
+            state_dim=get_feature_size(slot_config),
+            slot_config=slot_config,
+            device="cpu",
+            compile_mode="off",
+        )
+        agent = PPOAgent(policy=policy, device="cpu")
+        agent.save(tmp_path / "agent.pt")
+
+        checkpoint = torch.load(tmp_path / "agent.pt", weights_only=False)
+        checkpoint["config"]["n_epochs"] = 4
+        torch.save(checkpoint, tmp_path / "removed_n_epochs.pt")
+
+        with pytest.raises(RuntimeError, match="config.n_epochs"):
+            PPOAgent.load(tmp_path / "removed_n_epochs.pt", device="cpu")
+
 
 class TestPPOCheckpointVersion:
     """Checkpoint version handling."""


### PR DESCRIPTION
## Summary

- Make PPO checkpoint loading fail fast when `aux_training_step` is missing or removed `config.n_epochs` is present.
- Preserve `finiteness_gate_failures` as a list, including the successful-update empty-list case.
- Refresh `PPOUpdateMetrics` to match currently emitted PPO update keys and remove stale Simic `GradientStats` exposure.
- Remove the stale leyline boundary whitelist entry and update recovery coordination docs.
- Removed Filigree from the local UV tool install; Legis, Loomweave, and Wardline remain installed. Filigree issue closure is pending a writable tracker surface.

## Verification

- `uv run pytest tests/simic/test_ppo_checkpoint.py tests/simic/agent/test_ppo_finiteness_gate.py tests/simic/agent/test_ppo_metrics_contract.py -q`
- `uv run python scripts/lint_defensive_patterns.py`
- `uv run python scripts/lint_leyline_types.py`
- `uv run python scripts/lint_gpu_sync.py`
- `uv run ruff check src/ tests/`
- `MYPYPATH=src uv run mypy -p esper`
- `uv run pytest` (`4686 passed, 10 skipped, 69 deselected`)
- `wardline scan . --fail-on ERROR` (`0 active`)

## Notes

Targets local fixes for `esper-lite-aa2a27`, `esper-lite-dcb298`, and `esper-lite-860e79`.
