### PR TITLE
fix(simic): preserve alpha curve contracts

### DIFF
--- a/docs/coord/PLAN_TRACKER.md
+++ b/docs/coord/PLAN_TRACKER.md
@@ -1,6 +1,6 @@
 # Esper Plan Tracker
 
-**Last Updated:** 2026-06-13 (baseline green; P1 follow-up PRs merged; first P2 contract batch locally verified)
+**Last Updated:** 2026-06-13 (baseline green; P1 follow-up PRs merged; PR #80 merged; second P2 batch locally verified)
 **Purpose:** Rack-and-stack all plans and concepts for prioritization and dependency tracking.
 
 ---
@@ -16,10 +16,10 @@ main CI passed. The active plan is
 
 Current operating rule: drain high-risk correctness bugs before feature work.
 Recovery PR #72 is merged. Follow-up PRs #78 and #79 merged telemetry and
-training-control correctness fixes with passing CI. The first P2 contract
-batch now has local fixes and passing static/full-test/Wardline gates on
-`codex/p2-steady-state-drain`; Filigree tracker closure is pending a writable
-tracker surface because the UV tool install was removed.
+training-control correctness fixes with passing CI. PR #80 merged the first
+P2 contract batch and closed three tracker bugs. The second P2 action/reward
+contract batch now has local fixes and passing focused/static/full-test/Wardline
+gates on `codex/p2-action-reward-contracts`; PR and tracker closure are next.
 
 ### Post-Hiatus Audit (2026-02-21)
 
@@ -70,7 +70,7 @@ the stored action. These ops frequently diverge, corrupting advantage estimates.
 
 | ID | Title | Type | Urgency | Complexity | Risk | Status |
 |----|-------|------|---------|------------|------|--------|
-| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: first P2 contract batch locally verified; PR/tracker closure pending |
+| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: second P2 action/reward batch locally verified; PR/tracker closure pending |
 | p1-stability-batch-1 | PPO/Telemetry Stability Batch 1 | completed-batch | 🔴 critical | M | high | Completed and merged; six bugs closed, broad gates passed |
 | filigree-p0-drain | Critical Filigree P0 Bug Drain | completed-batch | 🔴 critical | L | high | Initial six P0s fixed, verified, and closed |
 | op-value-mismatch | Q(s,op) Double-Sampling Bug | investigation | 🔴 critical | M | high | Diagnosed 2025-12-31, blocks Phase 7. See `docs/bugs/investigations/` |

--- a/docs/plans/ready/2026-06-12-green-state-recovery.md
+++ b/docs/plans/ready/2026-06-12-green-state-recovery.md
@@ -30,12 +30,12 @@ status_notes: >
   PR #52 was made green, accepted, and merged as the new baseline on 2026-06-12.
   Main CI passed on merge commit cdff9c43. Recovery PR #72 landed the initial
   P0 Filigree bug drain and project Filigree install removal. Follow-up PRs
-  #78 and #79 merged telemetry and training-control correctness fixes. The
-  repository is green on CI, but not yet steady. The first P2 contract batch
-  is locally fixed and verified against checkpoint, PPO metrics, type, lint,
-  full pytest, and Wardline gates. Filigree tracker closure is pending an
-  available update surface after removing the UV tool install.
-percent_complete: 80
+  #78 and #79 merged telemetry and training-control correctness fixes. PR #80
+  merged the first P2 contract batch. The repository is green on CI, but not
+  yet steady. The second P2 action/reward contract batch is locally fixed and
+  verified against focused tests, custom guardrails, type, lint, full pytest,
+  and Wardline gates.
+percent_complete: 82
 
 reviewed_by:
   - reviewer: python-engineering
@@ -111,19 +111,37 @@ Return the project to a steady state:
   - `MYPYPATH=src uv run mypy -p esper`
   - `uv run pytest` (`4686 passed, 10 skipped, 69 deselected`)
   - `wardline scan . --fail-on ERROR` (`0 active`)
+- PR #80 (`codex/p2-steady-state-drain`) was merged into `main` on
+  2026-06-12 at merge commit `6676449bd972ea219613f027a376a36f3f4612d9`.
+- PR #80 verification run passed:
+  - `lint`
+  - `typecheck`
+  - `property-tests`
+  - `unit-and-integration-tests`
+  - `e2e-smoke-tests`
+- The first three P2 contract bugs were fixed and closed:
+  - `esper-lite-aa2a27` PPO checkpoint metadata declared fields not emitted
+  - `esper-lite-dcb298` PPO update metrics contract included stale keys
+  - `esper-lite-860e79` all-epochs-skipped updates emitted zeroed metrics
+- Local second P2 action/reward contract batch verification on 2026-06-13 passed:
+  - `uv run pytest tests/simic/training/handlers/test_alpha_handler.py tests/simic/training/handlers/test_prune_handler.py tests/simic/test_reward_telemetry.py -q`
+  - `uv run python scripts/lint_defensive_patterns.py`
+  - `uv run python scripts/lint_leyline_types.py`
+  - `uv run python scripts/lint_gpu_sync.py`
+  - `uv run ruff check src/ tests/`
+  - `MYPYPATH=src uv run mypy -p esper`
+  - `uv run pytest` (`4690 passed, 10 skipped, 69 deselected`)
+  - `wardline scan . --fail-on ERROR` (`0 active`)
 - Filigree was removed from the UV tool install on 2026-06-13:
   `uv tool uninstall filigree` removed `filigree`, `filigree-dashboard`,
   `filigree-mcp`, `filigree-scanner-claude`, and `filigree-scanner-codex`.
   `uv tool list` now retains only Legis, Loomweave, Loomweave plugins, and
   Wardline from the local standard tooling set.
-- Filigree on 2026-06-13 reports `22 ready`, `0 blocked`, and `0 wip`.
-  The ready queue includes 19 P2 bugs and 2 P3 bugs plus the future release
-  placeholder.
-- Loomweave MCP is reachable, but the active MCP server still reports no
-  `.weft/loomweave/loomweave.db`. The index exists in `/home/john/esper-lite`
-  and is absent in the clean recovery worktree, so code archaeology must fall
-  back to shell search until the server is reconnected or the index is copied
-  into the worktree.
+- Filigree on 2026-06-13 reports `17 ready`, `0 blocked`, and `2 wip`
+  after claiming `esper-lite-642150` and `esper-lite-c8d465`.
+- Loomweave MCP is visible, but the active MCP server still reports no
+  `.weft/loomweave/loomweave.db` even after a worktree analysis pass. The
+  available MCP session needs a reconnect before graph queries can be used.
 - The working tree also contains unrelated dirty skill/config files. These must not be reverted or silently included in the PR #52 stabilization commit.
 
 ## Definition Of Green

--- a/src/esper/simic/rewards/reward_telemetry.py
+++ b/src/esper/simic/rewards/reward_telemetry.py
@@ -13,6 +13,19 @@ if TYPE_CHECKING:
     from esper.simic.rewards.contribution import FossilizedSeedDripState
 
 
+def _parse_bool_field(value: float | int | str | bool | None, field_name: str) -> bool:
+    """Parse serialized boolean telemetry without truthiness coercion."""
+    if type(value) is bool:
+        return value
+    if type(value) is str:
+        normalized = value.lower()
+        if normalized == "true":
+            return True
+        if normalized == "false":
+            return False
+    raise ValueError(f"{field_name} must be bool, 'True', or 'False'; got {value!r}")
+
+
 @dataclass(slots=True)
 class RewardComponentsTelemetry:
     """Breakdown of reward components for debugging.
@@ -229,7 +242,7 @@ class RewardComponentsTelemetry:
             num_fossilized_seeds=int(data["num_fossilized_seeds"]),  # type: ignore[arg-type]
             num_contributing_fossilized=int(data["num_contributing_fossilized"]),  # type: ignore[arg-type]
             action_name=str(data["action_name"]),
-            action_success=bool(data["action_success"]),
+            action_success=_parse_bool_field(data["action_success"], "action_success"),
             seed_stage=int(data["seed_stage"]) if data["seed_stage"] is not None else None,
             epoch=int(data["epoch"]),  # type: ignore[arg-type]
             val_acc=float(data["val_acc"]),  # type: ignore[arg-type]

--- a/src/esper/simic/training/action_execution.py
+++ b/src/esper/simic/training/action_execution.py
@@ -851,11 +851,13 @@ def execute_actions(
                     ]
                     curve_action_obj = AlphaCurveAction(alpha_curve_action)
                     curve = curve_action_obj.to_curve()
+                    steepness = curve_action_obj.to_steepness()
 
                     # Schedule prune: force alpha to 0 with requested speed/curve.
                     action_success = slot_obj.schedule_prune(
                         steps=speed_steps,
                         curve=curve,
+                        steepness=steepness,
                         initiator="policy",
                     )
                     if action_success:
@@ -866,10 +868,12 @@ def execute_actions(
                     ]
                     curve_action_obj = AlphaCurveAction(alpha_curve_action)
                     curve = curve_action_obj.to_curve()
+                    steepness = curve_action_obj.to_steepness()
                     action_success = slot_obj.set_alpha_target(
                         alpha_target=alpha_target,
                         steps=speed_steps,
                         curve=curve,
+                        steepness=steepness,
                         alpha_algorithm=alpha_algorithm,
                         initiator="policy",
                     )

--- a/src/esper/simic/training/handlers/alpha.py
+++ b/src/esper/simic/training/handlers/alpha.py
@@ -123,6 +123,7 @@ def execute_set_alpha_target(
     speed_steps = ALPHA_SPEED_TO_STEPS[AlphaSpeedAction(params.alpha_speed_idx)]
     curve_action = AlphaCurveAction(params.alpha_curve_idx)
     curve = curve_action.to_curve()
+    steepness = curve_action.to_steepness()
     alpha_algorithm = STYLE_ALPHA_ALGORITHMS[params.style_idx]
 
     # Record current alpha for telemetry
@@ -133,6 +134,7 @@ def execute_set_alpha_target(
         alpha_target=alpha_target,
         steps=speed_steps,
         curve=curve,
+        steepness=steepness,
         alpha_algorithm=alpha_algorithm,
         initiator="policy",
     )
@@ -150,6 +152,7 @@ def execute_set_alpha_target(
             "alpha_target": alpha_target,
             "speed_steps": speed_steps,
             "curve": curve.name if curve else None,
+            "steepness": steepness,
             "alpha_algorithm": alpha_algorithm.name if alpha_algorithm else None,
         },
     )

--- a/tests/simic/test_reward_telemetry.py
+++ b/tests/simic/test_reward_telemetry.py
@@ -111,3 +111,29 @@ class TestRewardComponentsTelemetry:
 
         with pytest.raises(KeyError, match="timing_discount"):
             RewardComponentsTelemetry.from_dict(data)
+
+    def test_from_dict_parses_false_action_success_string(self):
+        """String boolean telemetry from intermediate exports preserves False."""
+        data = RewardComponentsTelemetry(action_success=True).to_dict()
+        data["action_success"] = "False"
+
+        restored = RewardComponentsTelemetry.from_dict(data)
+
+        assert restored.action_success is False
+
+    def test_from_dict_parses_true_action_success_string(self):
+        """String boolean telemetry from intermediate exports preserves True."""
+        data = RewardComponentsTelemetry(action_success=False).to_dict()
+        data["action_success"] = "True"
+
+        restored = RewardComponentsTelemetry.from_dict(data)
+
+        assert restored.action_success is True
+
+    def test_from_dict_rejects_invalid_action_success_string(self):
+        """Malformed action_success strings should fail instead of guessing."""
+        data = RewardComponentsTelemetry(action_success=True).to_dict()
+        data["action_success"] = "truthy"
+
+        with pytest.raises(ValueError, match="action_success"):
+            RewardComponentsTelemetry.from_dict(data)

--- a/tests/simic/training/handlers/test_alpha_handler.py
+++ b/tests/simic/training/handlers/test_alpha_handler.py
@@ -1,0 +1,73 @@
+"""Unit tests for the SET_ALPHA_TARGET operation handler."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from esper.leyline import (
+    ALPHA_TARGET_VALUES,
+    AlphaCurveAction,
+    AlphaMode,
+    AlphaSpeedAction,
+    SeedStage,
+    STYLE_ALPHA_ALGORITHMS,
+)
+from esper.simic.training.handlers import (
+    AlphaTargetParams,
+    HandlerContext,
+    execute_set_alpha_target,
+)
+from esper.simic.training.parallel_env_state import ParallelEnvState
+
+
+@pytest.fixture
+def alpha_target_context() -> HandlerContext:
+    """Create a HandlerContext with a seed eligible for alpha retargeting."""
+    env_state = MagicMock(spec=ParallelEnvState)
+
+    seed_state = MagicMock()
+    seed_state.stage = SeedStage.HOLDING
+    seed_state.alpha_controller.alpha_mode = AlphaMode.HOLD
+
+    slot = MagicMock()
+    slot.alpha = 1.0
+    slot.set_alpha_target.return_value = True
+
+    return HandlerContext(
+        env_idx=0,
+        slot_id="r0c0",
+        env_state=env_state,
+        model=MagicMock(),
+        slot=slot,
+        seed_state=seed_state,
+        epoch=5,
+        max_epochs=150,
+        episodes_completed=0,
+    )
+
+
+def test_execute_set_alpha_target_passes_sigmoid_steepness(
+    alpha_target_context: HandlerContext,
+) -> None:
+    """Policy-selected sigmoid variants must reach the slot retarget call."""
+    params = AlphaTargetParams(
+        alpha_target_idx=0,
+        alpha_speed_idx=AlphaSpeedAction.FAST.value,
+        alpha_curve_idx=AlphaCurveAction.SIGMOID_SHARP.value,
+        style_idx=0,
+    )
+
+    result = execute_set_alpha_target(alpha_target_context, params)
+
+    assert result.success is True
+    alpha_target_context.slot.set_alpha_target.assert_called_once_with(
+        alpha_target=ALPHA_TARGET_VALUES[params.alpha_target_idx],
+        steps=3,
+        curve=AlphaCurveAction.SIGMOID_SHARP.to_curve(),
+        steepness=AlphaCurveAction.SIGMOID_SHARP.to_steepness(),
+        alpha_algorithm=STYLE_ALPHA_ALGORITHMS[params.style_idx],
+        initiator="policy",
+    )
+    assert result.telemetry["steepness"] == pytest.approx(24.0)


### PR DESCRIPTION
## Summary
- Pass policy-selected alpha curve steepness through SET_ALPHA_TARGET handler and active execute_actions path
- Preserve PRUNE steepness in the active execute_actions path to match the handler contract
- Parse serialized RewardComponentsTelemetry.action_success booleans explicitly instead of truthiness-coercing strings
- Update recovery tracker docs for PR #80 and this locally verified P2 batch

## Verification
- uv run pytest tests/simic/training/handlers/test_alpha_handler.py tests/simic/training/handlers/test_prune_handler.py tests/simic/test_reward_telemetry.py -q
- uv run python scripts/lint_defensive_patterns.py
- uv run python scripts/lint_leyline_types.py
- uv run python scripts/lint_gpu_sync.py
- uv run ruff check src/ tests/
- MYPYPATH=src uv run mypy -p esper
- uv run pytest (4690 passed, 10 skipped, 69 deselected)
- wardline scan . --fail-on ERROR (0 active)
