### PR TITLE
fix(simic): require counterfactual telemetry inputs

### DIFF
--- a/docs/coord/PLAN_TRACKER.md
+++ b/docs/coord/PLAN_TRACKER.md
@@ -1,6 +1,6 @@
 # Esper Plan Tracker
 
-**Last Updated:** 2026-06-13 (baseline green; P1 follow-up PRs merged; PR #80 merged; second P2 batch locally verified)
+**Last Updated:** 2026-06-13 (baseline green; P1 follow-up PRs merged; PRs #80/#81 merged; counterfactual P2 batch locally verified)
 **Purpose:** Rack-and-stack all plans and concepts for prioritization and dependency tracking.
 
 ---
@@ -17,9 +17,10 @@ main CI passed. The active plan is
 Current operating rule: drain high-risk correctness bugs before feature work.
 Recovery PR #72 is merged. Follow-up PRs #78 and #79 merged telemetry and
 training-control correctness fixes with passing CI. PR #80 merged the first
-P2 contract batch and closed three tracker bugs. The second P2 action/reward
-contract batch now has local fixes and passing focused/static/full-test/Wardline
-gates on `codex/p2-action-reward-contracts`; PR and tracker closure are next.
+P2 contract batch and closed three tracker bugs. PR #81 merged the second P2
+action/reward contract batch and closed two tracker bugs. The P2 counterfactual
+telemetry batch now has local fixes and passing focused/static/full-test/Wardline
+gates on `codex/p2-counterfactual-telemetry`; PR and tracker closure are next.
 
 ### Post-Hiatus Audit (2026-02-21)
 
@@ -70,7 +71,7 @@ the stored action. These ops frequently diverge, corrupting advantage estimates.
 
 | ID | Title | Type | Urgency | Complexity | Risk | Status |
 |----|-------|------|---------|------------|------|--------|
-| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: second P2 action/reward batch locally verified; PR/tracker closure pending |
+| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: P2 counterfactual telemetry batch locally verified; PR/tracker closure pending |
 | p1-stability-batch-1 | PPO/Telemetry Stability Batch 1 | completed-batch | 🔴 critical | M | high | Completed and merged; six bugs closed, broad gates passed |
 | filigree-p0-drain | Critical Filigree P0 Bug Drain | completed-batch | 🔴 critical | L | high | Initial six P0s fixed, verified, and closed |
 | op-value-mismatch | Q(s,op) Double-Sampling Bug | investigation | 🔴 critical | M | high | Diagnosed 2025-12-31, blocks Phase 7. See `docs/bugs/investigations/` |

--- a/docs/plans/ready/2026-06-12-green-state-recovery.md
+++ b/docs/plans/ready/2026-06-12-green-state-recovery.md
@@ -31,11 +31,12 @@ status_notes: >
   Main CI passed on merge commit cdff9c43. Recovery PR #72 landed the initial
   P0 Filigree bug drain and project Filigree install removal. Follow-up PRs
   #78 and #79 merged telemetry and training-control correctness fixes. PR #80
-  merged the first P2 contract batch. The repository is green on CI, but not
-  yet steady. The second P2 action/reward contract batch is locally fixed and
-  verified against focused tests, custom guardrails, type, lint, full pytest,
-  and Wardline gates.
-percent_complete: 82
+  merged the first P2 contract batch, and PR #81 merged the second P2
+  action/reward contract batch. The repository is green on CI, but not yet
+  steady. The P2 counterfactual telemetry batch is locally fixed and verified
+  against focused tests, custom guardrails, type, lint, full pytest, and
+  Wardline gates.
+percent_complete: 84
 
 reviewed_by:
   - reviewer: python-engineering
@@ -132,13 +133,33 @@ Return the project to a steady state:
   - `MYPYPATH=src uv run mypy -p esper`
   - `uv run pytest` (`4690 passed, 10 skipped, 69 deselected`)
   - `wardline scan . --fail-on ERROR` (`0 active`)
+- PR #81 (`codex/p2-action-reward-contracts`) was merged into `main` on
+  2026-06-12 at merge commit `32ddc39df5018a70c68e5c3603d586759cb527bf`.
+- PR #81 verification run `27423441338` passed:
+  - `lint`
+  - `typecheck`
+  - `property-tests`
+  - `unit-and-integration-tests`
+  - `e2e-smoke-tests`
+- The second P2 action/reward contract bugs were fixed and closed:
+  - `esper-lite-642150` alpha target handling dropped sigmoid steepness variants
+  - `esper-lite-c8d465` reward telemetry deserialized string `"False"` as true
+- Local P2 counterfactual telemetry batch verification on 2026-06-13 passed:
+  - `uv run pytest tests/simic/attribution/test_counterfactual.py -q`
+  - `uv run python scripts/lint_defensive_patterns.py`
+  - `uv run python scripts/lint_leyline_types.py`
+  - `uv run python scripts/lint_gpu_sync.py`
+  - `uv run ruff check src/ tests/`
+  - `MYPYPATH=src uv run mypy -p esper`
+  - `uv run pytest` (`4694 passed, 10 skipped, 69 deselected`)
+  - `wardline scan . --fail-on ERROR` (`0 active`)
 - Filigree was removed from the UV tool install on 2026-06-13:
   `uv tool uninstall filigree` removed `filigree`, `filigree-dashboard`,
   `filigree-mcp`, `filigree-scanner-claude`, and `filigree-scanner-codex`.
   `uv tool list` now retains only Legis, Loomweave, Loomweave plugins, and
   Wardline from the local standard tooling set.
-- Filigree on 2026-06-13 reports `17 ready`, `0 blocked`, and `2 wip`
-  after claiming `esper-lite-642150` and `esper-lite-c8d465`.
+- Filigree on 2026-06-13 reports `15 ready`, `0 blocked`, and `2 wip`
+  after claiming `esper-lite-65d044` and `esper-lite-d9edae`.
 - Loomweave MCP is visible, but the active MCP server still reports no
   `.weft/loomweave/loomweave.db` even after a worktree analysis pass. The
   available MCP session needs a reconnect before graph queries can be used.

--- a/src/esper/simic/attribution/counterfactual.py
+++ b/src/esper/simic/attribution/counterfactual.py
@@ -273,11 +273,22 @@ class CounterfactualEngine:
         self,
         slot_ids: list[str],
         results: dict[tuple[bool, ...], tuple[float, float]],
+        *,
+        compute_time_seconds: float,
     ) -> CounterfactualMatrix:
         """Compute matrix from pre-calculated results (e.g. fused validation)."""
+        if compute_time_seconds < 0.0:
+            raise ValueError(
+                f"compute_time_seconds must be non-negative, got {compute_time_seconds}"
+            )
+
         n_seeds = len(slot_ids)
         strategy = self.config.effective_strategy(n_seeds)
-        matrix = CounterfactualMatrix(strategy_used=strategy, source="precomputed")
+        matrix = CounterfactualMatrix(
+            strategy_used=strategy,
+            source="precomputed",
+            compute_time_seconds=compute_time_seconds,
+        )
 
         # We assume the results passed in match what generate_configs would request,
         # or at least contain the subsets we care about.

--- a/src/esper/simic/attribution/counterfactual_helper.py
+++ b/src/esper/simic/attribution/counterfactual_helper.py
@@ -88,13 +88,19 @@ class CounterfactualHelper:
         self,
         slot_ids: list[str],
         results: dict[tuple[bool, ...], tuple[float, float]],
+        *,
+        compute_time_seconds: float,
         epoch: int | None = None,
     ) -> dict[str, ContributionResult]:
         """Compute contributions from pre-calculated batch results."""
         if not slot_ids:
             return {}
 
-        matrix = self.engine.compute_matrix_from_results(slot_ids, results)
+        matrix = self.engine.compute_matrix_from_results(
+            slot_ids,
+            results,
+            compute_time_seconds=compute_time_seconds,
+        )
         if epoch is not None:
             matrix.epoch = epoch  # Propagate PPO batch index for telemetry tagging
         return self._process_matrix(matrix, slot_ids)
@@ -216,12 +222,17 @@ def compute_simple_ablation(
     Returns:
         Dict mapping slot_id to contribution (removal cost)
     """
+    missing_slot_ids = [
+        slot_id for slot_id in slot_ids if slot_id not in per_slot_accuracy
+    ]
+    if missing_slot_ids:
+        raise KeyError(
+            "Missing per-slot ablation accuracy for slots: "
+            f"{', '.join(missing_slot_ids)}"
+        )
+
     contributions = {}
     for slot_id in slot_ids:
-        if slot_id in per_slot_accuracy:
-            # Removal cost = full - without_slot
-            # Positive means slot is helping
-            contributions[slot_id] = full_accuracy - per_slot_accuracy[slot_id]
-        else:
-            contributions[slot_id] = 0.0
+        # Removal cost = full - without_slot. Positive means slot is helping.
+        contributions[slot_id] = full_accuracy - per_slot_accuracy[slot_id]
     return contributions

--- a/src/esper/simic/training/vectorized_trainer.py
+++ b/src/esper/simic/training/vectorized_trainer.py
@@ -746,6 +746,7 @@ class VectorizedPPOTrainer:
                         )
 
                     # Iterate validation batches using shared iterator
+                    validation_start = time.perf_counter()
                     test_iter = iter(shared_test_iter)
                     for batch_step in range(num_test_batches):
                         try:
@@ -891,6 +892,7 @@ class VectorizedPPOTrainer:
                     for env_state in env_states:
                         if env_state.stream:
                             env_state.stream.synchronize()
+                    validation_elapsed_seconds = time.perf_counter() - validation_start
 
                     # PERF: Batch GPU→CPU transfer before iterating
                     # Moving tensors to CPU after sync is ~free (data already computed).
@@ -1110,6 +1112,7 @@ class VectorizedPPOTrainer:
                                 env_state.counterfactual_helper.compute_contributions_from_results(
                                     slot_ids=active_slots,
                                     results=shapley_results[i],
+                                    compute_time_seconds=validation_elapsed_seconds,
                                     epoch=batch_idx + 1,
                                 )
                             except (KeyError, ZeroDivisionError, ValueError) as e:

--- a/tests/simic/attribution/test_counterfactual.py
+++ b/tests/simic/attribution/test_counterfactual.py
@@ -11,6 +11,7 @@ from esper.simic.attribution.counterfactual import (
     CounterfactualMatrix,
     CounterfactualResult,
 )
+from esper.simic.attribution.counterfactual_helper import compute_simple_ablation
 
 
 class TestShapleyReproducibility:
@@ -341,6 +342,40 @@ class TestCounterfactualInteractions:
             engine.compute_interaction_terms(matrix)
 
 
+class TestCounterfactualPrecomputedTiming:
+    """Regression coverage for precomputed-matrix timing telemetry."""
+
+    def test_compute_matrix_from_results_records_elapsed_time(self):
+        """Fused validation callers must propagate measured compute time."""
+        engine = CounterfactualEngine()
+
+        matrix = engine.compute_matrix_from_results(
+            slot_ids=["r0c0"],
+            results={
+                (False,): (0.5, 0.50),
+                (True,): (0.3, 0.70),
+            },
+            compute_time_seconds=1.25,
+        )
+
+        assert matrix.source == "precomputed"
+        assert matrix.compute_time_seconds == pytest.approx(1.25)
+
+    def test_compute_matrix_from_results_rejects_negative_elapsed_time(self):
+        """Negative elapsed time is invalid telemetry input."""
+        engine = CounterfactualEngine()
+
+        with pytest.raises(ValueError, match="compute_time_seconds"):
+            engine.compute_matrix_from_results(
+                slot_ids=["r0c0"],
+                results={
+                    (False,): (0.5, 0.50),
+                    (True,): (0.3, 0.70),
+                },
+                compute_time_seconds=-0.1,
+            )
+
+
 class TestCounterfactualHelperShapley:
     """Regression coverage for helper-level Shapley processing."""
 
@@ -359,6 +394,7 @@ class TestCounterfactualHelperShapley:
                 (True,): (0.3, 0.70),
             },
             epoch=7,
+            compute_time_seconds=0.5,
         )
 
         assert contributions["r0c0"].contribution == pytest.approx(0.20)
@@ -382,11 +418,41 @@ class TestCounterfactualHelperShapley:
                 (True, True): (0.3, 0.75),
             },
             epoch=7,
+            compute_time_seconds=0.5,
         )
 
         assert helper.has_precomputed_matrix_for(["r0c0", "r0c1"], epoch=7)
         assert not helper.has_precomputed_matrix_for(["r0c1", "r0c0"], epoch=7)
         assert not helper.has_precomputed_matrix_for(["r0c0", "r0c1"], epoch=8)
+
+
+class TestSimpleAblation:
+    """Regression coverage for simple ablation input contracts."""
+
+    def test_compute_simple_ablation_raises_for_missing_slot_accuracy(self):
+        """Missing required slot measurements must fail loudly."""
+        with pytest.raises(KeyError, match="r0c1"):
+            compute_simple_ablation(
+                slot_ids=["r0c0", "r0c1"],
+                full_accuracy=80.0,
+                per_slot_accuracy={"r0c0": 70.0},
+            )
+
+    def test_compute_simple_ablation_uses_required_measurements(self):
+        """Removal costs are computed from explicit per-slot measurements."""
+        contributions = compute_simple_ablation(
+            slot_ids=["r0c0", "r0c1"],
+            full_accuracy=80.0,
+            per_slot_accuracy={
+                "r0c0": 70.0,
+                "r0c1": 75.0,
+            },
+        )
+
+        assert contributions == {
+            "r0c0": pytest.approx(10.0),
+            "r0c1": pytest.approx(5.0),
+        }
 
 
 class TestCounterfactualHelperReset:


### PR DESCRIPTION
## Summary
- Require precomputed counterfactual matrices to receive non-negative measured compute time
- Propagate fused validation elapsed time into Shapley/precomputed counterfactual telemetry
- Make simple ablation fail loudly when required per-slot measurements are missing
- Update recovery tracker docs for PR #81 and this locally verified P2 batch

## Verification
- uv run pytest tests/simic/attribution/test_counterfactual.py -q
- uv run python scripts/lint_defensive_patterns.py
- uv run python scripts/lint_leyline_types.py
- uv run python scripts/lint_gpu_sync.py
- uv run ruff check src/ tests/
- MYPYPATH=src uv run mypy -p esper
- uv run pytest (4694 passed, 10 skipped, 69 deselected)
- wardline scan . --fail-on ERROR (0 active)
