### PR TITLE
fix(simic): remove GPU sync hazards

### DIFF
--- a/docs/coord/PLAN_TRACKER.md
+++ b/docs/coord/PLAN_TRACKER.md
@@ -1,6 +1,6 @@
 # Esper Plan Tracker
 
-**Last Updated:** 2026-06-13 (baseline green; P1 follow-up PRs merged; PRs #80/#81 merged; counterfactual P2 batch locally verified)
+**Last Updated:** 2026-06-13 (baseline green; P1 follow-up PRs merged; PRs #80/#81/#82 merged; GPU-sync P2 batch locally verified)
 **Purpose:** Rack-and-stack all plans and concepts for prioritization and dependency tracking.
 
 ---
@@ -18,9 +18,10 @@ Current operating rule: drain high-risk correctness bugs before feature work.
 Recovery PR #72 is merged. Follow-up PRs #78 and #79 merged telemetry and
 training-control correctness fixes with passing CI. PR #80 merged the first
 P2 contract batch and closed three tracker bugs. PR #81 merged the second P2
-action/reward contract batch and closed two tracker bugs. The P2 counterfactual
-telemetry batch now has local fixes and passing focused/static/full-test/Wardline
-gates on `codex/p2-counterfactual-telemetry`; PR and tracker closure are next.
+action/reward contract batch and closed two tracker bugs. PR #82 merged the P2
+counterfactual telemetry batch and closed two tracker bugs. The P2 GPU-sync
+batch now has local fixes and passing focused/static/full-test/Wardline gates
+on `codex/p2-gpu-sync-contracts`; PR and tracker closure are next.
 
 ### Post-Hiatus Audit (2026-02-21)
 
@@ -71,7 +72,7 @@ the stored action. These ops frequently diverge, corrupting advantage estimates.
 
 | ID | Title | Type | Urgency | Complexity | Risk | Status |
 |----|-------|------|---------|------------|------|--------|
-| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: P2 counterfactual telemetry batch locally verified; PR/tracker closure pending |
+| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: P2 GPU-sync batch locally verified; PR/tracker closure pending |
 | p1-stability-batch-1 | PPO/Telemetry Stability Batch 1 | completed-batch | 🔴 critical | M | high | Completed and merged; six bugs closed, broad gates passed |
 | filigree-p0-drain | Critical Filigree P0 Bug Drain | completed-batch | 🔴 critical | L | high | Initial six P0s fixed, verified, and closed |
 | op-value-mismatch | Q(s,op) Double-Sampling Bug | investigation | 🔴 critical | M | high | Diagnosed 2025-12-31, blocks Phase 7. See `docs/bugs/investigations/` |

--- a/docs/plans/ready/2026-06-12-green-state-recovery.md
+++ b/docs/plans/ready/2026-06-12-green-state-recovery.md
@@ -30,13 +30,12 @@ status_notes: >
   PR #52 was made green, accepted, and merged as the new baseline on 2026-06-12.
   Main CI passed on merge commit cdff9c43. Recovery PR #72 landed the initial
   P0 Filigree bug drain and project Filigree install removal. Follow-up PRs
-  #78 and #79 merged telemetry and training-control correctness fixes. PR #80
-  merged the first P2 contract batch, and PR #81 merged the second P2
-  action/reward contract batch. The repository is green on CI, but not yet
-  steady. The P2 counterfactual telemetry batch is locally fixed and verified
-  against focused tests, custom guardrails, type, lint, full pytest, and
-  Wardline gates.
-percent_complete: 84
+  #78 and #79 merged telemetry and training-control correctness fixes. PRs
+  #80, #81, and #82 merged the first three P2 batches. The repository is green
+  on CI, but not yet steady. The P2 GPU-sync batch is locally fixed and
+  verified against focused tests, custom guardrails, type, lint, full pytest,
+  and Wardline gates.
+percent_complete: 86
 
 reviewed_by:
   - reviewer: python-engineering
@@ -153,13 +152,33 @@ Return the project to a steady state:
   - `MYPYPATH=src uv run mypy -p esper`
   - `uv run pytest` (`4694 passed, 10 skipped, 69 deselected`)
   - `wardline scan . --fail-on ERROR` (`0 active`)
+- PR #82 (`codex/p2-counterfactual-telemetry`) was merged into `main` on
+  2026-06-12 at merge commit `68398d4a447f2051eb423e3ebc07cc85802125ef`.
+- PR #82 verification run `27424591784` passed:
+  - `lint`
+  - `typecheck`
+  - `property-tests`
+  - `unit-and-integration-tests`
+  - `e2e-smoke-tests`
+- The P2 counterfactual telemetry bugs were fixed and closed:
+  - `esper-lite-65d044` counterfactual matrices persisted compute time as zero
+  - `esper-lite-d9edae` simple ablation treated missing data as neutral baseline
+- Local P2 GPU-sync batch verification on 2026-06-13 passed:
+  - `uv run pytest tests/simic/agent/test_rollout_buffer_unit.py tests/telemetry/test_environment_metrics.py -q`
+  - `uv run python scripts/lint_gpu_sync.py`
+  - `uv run python scripts/lint_leyline_types.py`
+  - `uv run python scripts/lint_defensive_patterns.py`
+  - `uv run ruff check src/ tests/`
+  - `MYPYPATH=src uv run mypy -p esper`
+  - `uv run pytest` (`4697 passed, 10 skipped, 69 deselected`)
+  - `wardline scan . --fail-on ERROR` (`0 active`)
 - Filigree was removed from the UV tool install on 2026-06-13:
   `uv tool uninstall filigree` removed `filigree`, `filigree-dashboard`,
   `filigree-mcp`, `filigree-scanner-claude`, and `filigree-scanner-codex`.
   `uv tool list` now retains only Legis, Loomweave, Loomweave plugins, and
   Wardline from the local standard tooling set.
-- Filigree on 2026-06-13 reports `15 ready`, `0 blocked`, and `2 wip`
-  after claiming `esper-lite-65d044` and `esper-lite-d9edae`.
+- Filigree on 2026-06-13 reports `13 ready`, `0 blocked`, and `2 wip`
+  after claiming `esper-lite-1eeab1` and `esper-lite-52d4c3`.
 - Loomweave MCP is visible, but the active MCP server still reports no
   `.weft/loomweave/loomweave.db` even after a worktree analysis pass. The
   available MCP session needs a reconnect before graph queries can be used.

--- a/src/esper/simic/agent/rollout_buffer.py
+++ b/src/esper/simic/agent/rollout_buffer.py
@@ -469,12 +469,13 @@ class TamiyoRolloutBuffer:
         rollouts). Would provide ~num_envs× speedup for this function.
         """
         # PERF: Pre-allocate zero tensor once (avoid O(steps * envs) allocations)
-        zero_tensor = torch.tensor(0.0, device=self.device)
+        zero_tensor = torch.tensor(0.0, device=self.device, dtype=self.values.dtype)
 
         # PERF: Pre-compute constants as tensors to avoid Python/tensor type mixing
         # in hot loop. This prevents type promotion overhead and ensures consistent dtype.
         gamma_t = torch.tensor(gamma, device=self.device, dtype=self.values.dtype)
         gamma_lambda_t = torch.tensor(gamma * gae_lambda, device=self.device, dtype=self.values.dtype)
+        one_tensor = torch.tensor(1.0, device=self.device, dtype=self.values.dtype)
 
         for env_id in range(self.num_envs):
             num_steps = self.step_counts[env_id]
@@ -504,23 +505,23 @@ class TamiyoRolloutBuffer:
             for t in reversed(range(num_steps)):
                 if t == num_steps - 1:
                     # Last step: use bootstrap value if truncated
-                    if truncated[t]:
-                        next_value = bootstrap_values[t]
-                        # Truncation is NOT a true terminal - the episode was cut off
-                        # by time limit. We MUST use next_non_terminal=1.0 so the
-                        # bootstrap value contributes to delta and GAE propagates.
-                        next_non_terminal = 1.0
-                    else:
-                        next_value = zero_tensor
-                        next_non_terminal = 1.0 - float(dones[t])
+                    next_value = torch.where(truncated[t], bootstrap_values[t], zero_tensor)
+                    # Truncation is NOT a true terminal - the episode was cut off
+                    # by time limit. We MUST use next_non_terminal=1.0 so the
+                    # bootstrap value contributes to delta and GAE propagates.
+                    next_non_terminal = torch.where(
+                        truncated[t],
+                        one_tensor,
+                        one_tensor - dones[t].to(dtype=self.values.dtype),
+                    )
                 else:
                     next_value = values[t + 1]
                     # For non-terminal steps, only reset on TRUE terminal (not truncation)
-                    next_non_terminal = 1.0 - float(dones[t] and not truncated[t])
+                    true_terminal = dones[t] & ~truncated[t]
+                    next_non_terminal = one_tensor - true_terminal.to(dtype=self.values.dtype)
 
                 # Reset GAE at true terminal (not truncation)
-                if dones[t] and not truncated[t]:
-                    last_gae = zero_tensor.clone()
+                last_gae = last_gae * next_non_terminal
 
                 delta = rewards[t] + gamma_t * next_value * next_non_terminal - values[t]
                 last_gae = delta + gamma_lambda_t * next_non_terminal * last_gae

--- a/src/esper/simic/telemetry/observation_stats.py
+++ b/src/esper/simic/telemetry/observation_stats.py
@@ -172,13 +172,10 @@ def compute_observation_stats(
     total_elements = batch_size * obs_dim
 
     # Replace NaN/Inf with 0 for stats computation
-    # Check via .any() which is faster than sum > 0 for sparse masks
-    has_bad_values = nan_mask.any() or inf_mask.any()
-    if has_bad_values:
-        clean_obs = obs_tensor.clone()
-        clean_obs[nan_mask | inf_mask] = 0.0
-    else:
-        clean_obs = obs_tensor
+    # Keep the decision tensor-native; branching on nan_mask.any() / inf_mask.any()
+    # would synchronize CUDA tensors with the host on every telemetry sample.
+    zero = torch.zeros((), device=obs_tensor.device, dtype=obs_tensor.dtype)
+    clean_obs = torch.where(nan_mask | inf_mask, zero, obs_tensor)
 
     # Group stats (Obs V3 layout)
     host = clean_obs[:, :_OBS_V3_HOST_FEATURE_SIZE]

--- a/tests/simic/agent/test_rollout_buffer_unit.py
+++ b/tests/simic/agent/test_rollout_buffer_unit.py
@@ -6,6 +6,8 @@ Property tests in test_buffer_properties.py cover mathematical properties.
 
 from __future__ import annotations
 
+import inspect
+
 import pytest
 import torch
 
@@ -409,6 +411,48 @@ class TestNormalizeAdvantages:
         assert mean != mean  # NaN check
         assert std != std
         # std_floored should be False when returning NaN (already normalized)
+
+
+class TestComputeAdvantagesAndReturns:
+    """Tests for GAE advantage and return computation."""
+
+    def _make_buffer(self) -> TamiyoRolloutBuffer:
+        return TamiyoRolloutBuffer(
+            num_envs=1,
+            max_steps_per_env=4,
+            state_dim=8,
+        )
+
+    def test_gae_loop_does_not_branch_on_tensor_scalars(self) -> None:
+        """GAE must not use CUDA tensor truthiness or scalar extraction in the loop."""
+        source = inspect.getsource(TamiyoRolloutBuffer.compute_advantages_and_returns)
+
+        assert "if truncated[t]" not in source
+        assert "float(dones[t]" not in source
+        assert "dones[t] and not truncated[t]" not in source
+
+    def test_terminal_reset_and_truncation_bootstrap_preserved(self) -> None:
+        """GAE resets at true terminals and bootstraps truncated final steps."""
+        buffer = self._make_buffer()
+        buffer.step_counts[0] = 4
+        buffer.rewards[0, :4] = torch.tensor([1.0, 1.0, 10.0, 2.0])
+        buffer.values[0, :4] = torch.tensor([0.5, 0.25, 1.0, 0.75])
+        buffer.dones[0, :4] = torch.tensor([False, True, False, True])
+        buffer.truncated[0, :4] = torch.tensor([False, False, False, True])
+        buffer.bootstrap_values[0, :4] = torch.tensor([0.0, 0.0, 0.0, 4.0])
+
+        buffer.compute_advantages_and_returns(gamma=0.9, gae_lambda=0.5)
+
+        expected_advantages = torch.tensor([
+            1.0625,
+            0.75,
+            11.8575,
+            4.85,
+        ])
+        expected_returns = expected_advantages + buffer.values[0, :4]
+
+        assert torch.allclose(buffer.advantages[0, :4], expected_advantages)
+        assert torch.allclose(buffer.returns[0, :4], expected_returns)
 
 
 class TestGetBatchedSequences:

--- a/tests/telemetry/test_environment_metrics.py
+++ b/tests/telemetry/test_environment_metrics.py
@@ -11,6 +11,7 @@ These tests cover:
 - TELE-650: env_status (FULLY WIRED)
 """
 
+import inspect
 from dataclasses import fields
 from datetime import datetime, timezone
 from unittest.mock import MagicMock
@@ -325,6 +326,13 @@ class TestTELE603NormalizationDrift:
         )
 
         assert obs_stats.normalization_drift == pytest.approx(1.0)
+
+    def test_observation_stats_does_not_branch_on_tensor_masks(self) -> None:
+        """NaN/Inf cleanup must not use CUDA tensor truthiness checks."""
+        source = inspect.getsource(compute_observation_stats)
+
+        assert "nan_mask.any() or inf_mask.any()" not in source
+        assert "if has_bad_values" not in source
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- keep GAE terminal/truncation decisions tensor-native to avoid per-step CUDA scalar syncs
- replace observation NaN/Inf cleanup tensor truthiness with torch.where
- add regression coverage for the GPU-sync contracts and update recovery status docs

## Verification
- uv run pytest tests/simic/agent/test_rollout_buffer_unit.py tests/telemetry/test_environment_metrics.py -q
- uv run python scripts/lint_gpu_sync.py
- uv run python scripts/lint_leyline_types.py
- uv run python scripts/lint_defensive_patterns.py
- uv run ruff check src/ tests/
- MYPYPATH=src uv run mypy -p esper
- uv run pytest (4697 passed, 10 skipped, 69 deselected)
- wardline scan . --fail-on ERROR (0 active)
