### PR TITLE
fix(simic): harden Dual-AB config contracts

### DIFF
--- a/docs/coord/PLAN_TRACKER.md
+++ b/docs/coord/PLAN_TRACKER.md
@@ -1,6 +1,6 @@
 # Esper Plan Tracker
 
-**Last Updated:** 2026-06-13 (baseline green; P1 follow-up PRs merged; PRs #80/#81/#82 merged; GPU-sync P2 batch locally verified)
+**Last Updated:** 2026-06-13 (baseline green; P1 follow-up PRs merged; PRs #80/#81/#82/#83 merged; Dual-AB P2 batch locally verified)
 **Purpose:** Rack-and-stack all plans and concepts for prioritization and dependency tracking.
 
 ---
@@ -19,9 +19,10 @@ Recovery PR #72 is merged. Follow-up PRs #78 and #79 merged telemetry and
 training-control correctness fixes with passing CI. PR #80 merged the first
 P2 contract batch and closed three tracker bugs. PR #81 merged the second P2
 action/reward contract batch and closed two tracker bugs. PR #82 merged the P2
-counterfactual telemetry batch and closed two tracker bugs. The P2 GPU-sync
+counterfactual telemetry batch and closed two tracker bugs. PR #83 merged the
+P2 GPU-sync batch and closed two tracker bugs. The P2 Dual-AB config contract
 batch now has local fixes and passing focused/static/full-test/Wardline gates
-on `codex/p2-gpu-sync-contracts`; PR and tracker closure are next.
+on `codex/p2-dual-ab-config-contracts`; PR and tracker closure are next.
 
 ### Post-Hiatus Audit (2026-02-21)
 
@@ -35,7 +36,7 @@ op twice independently — once in `forward()` for value computation, once in `g
 the stored action. These ops frequently diverge, corrupting advantage estimates. Blocks Phase 7.
 
 ### Current Focus Areas
-1. **Green State Recovery** - 🔴 CRITICAL! Baseline green; first P2 contract batch locally verified
+1. **Green State Recovery** - 🔴 CRITICAL! Baseline green; Dual-AB P2 batch locally verified
 2. **P1 Stability Batch 1** - ✅ Completed and merged; six high-risk PPO/telemetry correctness bugs closed
 3. **P0 Filigree Bug Drain** - ✅ Initial six P0s fixed and closed
 4. **Op/Value Mismatch** - 🔴 CRITICAL! Fix double-sampling in factored_lstm.py
@@ -72,7 +73,7 @@ the stored action. These ops frequently diverge, corrupting advantage estimates.
 
 | ID | Title | Type | Urgency | Complexity | Risk | Status |
 |----|-------|------|---------|------------|------|--------|
-| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: P2 GPU-sync batch locally verified; PR/tracker closure pending |
+| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: P2 Dual-AB config batch locally verified; PR/tracker closure pending |
 | p1-stability-batch-1 | PPO/Telemetry Stability Batch 1 | completed-batch | 🔴 critical | M | high | Completed and merged; six bugs closed, broad gates passed |
 | filigree-p0-drain | Critical Filigree P0 Bug Drain | completed-batch | 🔴 critical | L | high | Initial six P0s fixed, verified, and closed |
 | op-value-mismatch | Q(s,op) Double-Sampling Bug | investigation | 🔴 critical | M | high | Diagnosed 2025-12-31, blocks Phase 7. See `docs/bugs/investigations/` |

--- a/docs/plans/ready/2026-06-12-green-state-recovery.md
+++ b/docs/plans/ready/2026-06-12-green-state-recovery.md
@@ -31,11 +31,11 @@ status_notes: >
   Main CI passed on merge commit cdff9c43. Recovery PR #72 landed the initial
   P0 Filigree bug drain and project Filigree install removal. Follow-up PRs
   #78 and #79 merged telemetry and training-control correctness fixes. PRs
-  #80, #81, and #82 merged the first three P2 batches. The repository is green
-  on CI, but not yet steady. The P2 GPU-sync batch is locally fixed and
-  verified against focused tests, custom guardrails, type, lint, full pytest,
-  and Wardline gates.
-percent_complete: 86
+  #80, #81, #82, and #83 merged the first four P2 batches. The repository is
+  green on CI, but not yet steady. The P2 Dual-AB config contract batch is
+  locally fixed and verified against focused tests, custom guardrails, type,
+  lint, full pytest, and Wardline gates.
+percent_complete: 88
 
 reviewed_by:
   - reviewer: python-engineering
@@ -172,13 +172,33 @@ Return the project to a steady state:
   - `MYPYPATH=src uv run mypy -p esper`
   - `uv run pytest` (`4697 passed, 10 skipped, 69 deselected`)
   - `wardline scan . --fail-on ERROR` (`0 active`)
+- PR #83 (`codex/p2-gpu-sync-contracts`) was merged into `main` on
+  2026-06-12 at merge commit `5036b592fbbbf89309fcedff056bac500d444d51`.
+- PR #83 verification run `27425740842` passed:
+  - `lint`
+  - `typecheck`
+  - `property-tests`
+  - `unit-and-integration-tests`
+  - `e2e-smoke-tests`
+- The P2 GPU-sync bugs were fixed and closed:
+  - `esper-lite-1eeab1` GAE loop forced per-step CUDA sync via scalar extraction
+  - `esper-lite-52d4c3` observation stats used tensor truthiness checks
+- Local P2 Dual-AB config contract batch verification on 2026-06-13 passed:
+  - `uv run pytest tests/simic/training/test_dual_ab.py -q`
+  - `uv run python scripts/lint_defensive_patterns.py`
+  - `uv run python scripts/lint_leyline_types.py`
+  - `uv run python scripts/lint_gpu_sync.py`
+  - `uv run ruff check src/ tests/`
+  - `MYPYPATH=src uv run mypy -p esper`
+  - `uv run pytest` (`4699 passed, 10 skipped, 69 deselected`)
+  - `wardline scan . --fail-on ERROR` (`0 active`)
 - Filigree was removed from the UV tool install on 2026-06-13:
   `uv tool uninstall filigree` removed `filigree`, `filigree-dashboard`,
   `filigree-mcp`, `filigree-scanner-claude`, and `filigree-scanner-codex`.
   `uv tool list` now retains only Legis, Loomweave, Loomweave plugins, and
   Wardline from the local standard tooling set.
-- Filigree on 2026-06-13 reports `13 ready`, `0 blocked`, and `2 wip`
-  after claiming `esper-lite-1eeab1` and `esper-lite-52d4c3`.
+- Filigree on 2026-06-13 reports `11 ready`, `0 blocked`, and `2 wip`
+  after claiming `esper-lite-5bc044` and `esper-lite-78a856`.
 - Loomweave MCP is visible, but the active MCP server still reports no
   `.weft/loomweave/loomweave.db` even after a worktree analysis pass. The
   available MCP session needs a reconnect before graph queries can be used.

--- a/src/esper/simic/training/dual_ab.py
+++ b/src/esper/simic/training/dual_ab.py
@@ -152,6 +152,9 @@ def train_dual_policy_ab(
         raise ValueError(
             f"Need at least 2 groups for A/B testing, got {len(group_configs)}"
         )
+    group_ids = [group_id for group_id, _reward_mode in group_configs]
+    if len(set(group_ids)) != len(group_ids):
+        raise ValueError("Dual A/B group_id values must be unique")
 
     # Auto-detect devices if not provided
     if devices is None:
@@ -262,11 +265,7 @@ def _print_dual_ab_comparison(
 
         final_acc = avg_accs[-1] if avg_accs else 0.0
         best_acc = max(avg_accs) if avg_accs else 0.0
-        # Use rolling_avg_accuracy if available, otherwise avg_accuracy
-        rolling_accs = [
-            cast(float, batch.get("rolling_avg_accuracy", batch.get("avg_accuracy", 0.0)))
-            for batch in history
-        ]
+        rolling_accs = [cast(float, batch["rolling_avg_accuracy"]) for batch in history]
         avg_rolling = sum(rolling_accs) / len(rolling_accs) if rolling_accs else 0.0
 
         group_stats.append({

--- a/tests/simic/training/test_dual_ab.py
+++ b/tests/simic/training/test_dual_ab.py
@@ -42,6 +42,21 @@ class TestTrainDualPolicyAB:
                 n_episodes=1,
             )
 
+    def test_validates_unique_group_ids(self):
+        """Duplicate group IDs would corrupt result and telemetry grouping."""
+        from esper.simic.training.dual_ab import train_dual_policy_ab
+
+        with pytest.raises(ValueError, match="group_id values must be unique"):
+            train_dual_policy_ab(
+                n_envs_per_group=1,
+                group_configs=[
+                    ("A", RewardMode.SHAPED),
+                    ("A", RewardMode.SIMPLIFIED),
+                ],
+                devices=["cpu", "cpu"],
+                n_episodes=1,
+            )
+
     @pytest.mark.skipif(
         torch.cuda.is_available(),
         reason="Test expects CUDA to be unavailable",
@@ -120,6 +135,21 @@ class TestTrainDualPolicyAB:
 
         # Seeds should be different
         assert group_a_seed != group_b_seed
+
+    def test_comparison_requires_rolling_accuracy_metric(self):
+        """Comparison summaries fail fast when history violates its contract."""
+        from esper.simic.training.dual_ab import _print_dual_ab_comparison
+
+        results = {
+            "A": (None, [{"avg_accuracy": 50.0}]),
+            "B": (None, [{"avg_accuracy": 60.0, "rolling_avg_accuracy": 60.0}]),
+        }
+
+        with pytest.raises(KeyError, match="rolling_avg_accuracy"):
+            _print_dual_ab_comparison(
+                [("A", RewardMode.SHAPED), ("B", RewardMode.SIMPLIFIED)],
+                results,
+            )
 
 
 class TestTelemetryGroupId:


### PR DESCRIPTION
## Summary
- reject duplicate Dual-AB group IDs before training starts
- remove defensive metric fallback in Dual-AB comparison summaries
- add regression coverage for duplicate group IDs and missing rolling accuracy history
- update recovery tracker docs with PR #83 and this local verification slice

## Verification
- uv run pytest tests/simic/training/test_dual_ab.py -q
- uv run python scripts/lint_defensive_patterns.py
- uv run python scripts/lint_leyline_types.py
- uv run python scripts/lint_gpu_sync.py
- uv run ruff check src/ tests/
- MYPYPATH=src uv run mypy -p esper
- uv run pytest (4699 passed, 10 skipped, 69 deselected)
- wardline scan . --fail-on ERROR (0 active)
