### PR TITLE
fix(simic): enforce config contract validation

### DIFF
--- a/docs/coord/PLAN_TRACKER.md
+++ b/docs/coord/PLAN_TRACKER.md
@@ -1,6 +1,6 @@
 # Esper Plan Tracker
 
-**Last Updated:** 2026-06-13 (baseline green; P1 follow-up PRs merged; PRs #80/#81/#82/#83 merged; Dual-AB P2 batch locally verified)
+**Last Updated:** 2026-06-13 (baseline green; P1 follow-up PRs merged; PRs #80/#81/#82/#83/#84 merged; config P2 batch locally verified)
 **Purpose:** Rack-and-stack all plans and concepts for prioritization and dependency tracking.
 
 ---
@@ -20,9 +20,10 @@ training-control correctness fixes with passing CI. PR #80 merged the first
 P2 contract batch and closed three tracker bugs. PR #81 merged the second P2
 action/reward contract batch and closed two tracker bugs. PR #82 merged the P2
 counterfactual telemetry batch and closed two tracker bugs. PR #83 merged the
-P2 GPU-sync batch and closed two tracker bugs. The P2 Dual-AB config contract
-batch now has local fixes and passing focused/static/full-test/Wardline gates
-on `codex/p2-dual-ab-config-contracts`; PR and tracker closure are next.
+P2 GPU-sync batch and closed two tracker bugs. PR #84 merged the P2 Dual-AB
+config contract batch and closed two tracker bugs. The P2 config-contract batch
+now has local fixes and passing focused/static/full-test/Wardline gates on
+`codex/p2-config-contracts`; PR and tracker closure are next.
 
 ### Post-Hiatus Audit (2026-02-21)
 
@@ -36,7 +37,7 @@ op twice independently — once in `forward()` for value computation, once in `g
 the stored action. These ops frequently diverge, corrupting advantage estimates. Blocks Phase 7.
 
 ### Current Focus Areas
-1. **Green State Recovery** - 🔴 CRITICAL! Baseline green; Dual-AB P2 batch locally verified
+1. **Green State Recovery** - 🔴 CRITICAL! Baseline green; config P2 batch locally verified
 2. **P1 Stability Batch 1** - ✅ Completed and merged; six high-risk PPO/telemetry correctness bugs closed
 3. **P0 Filigree Bug Drain** - ✅ Initial six P0s fixed and closed
 4. **Op/Value Mismatch** - 🔴 CRITICAL! Fix double-sampling in factored_lstm.py
@@ -73,7 +74,7 @@ the stored action. These ops frequently diverge, corrupting advantage estimates.
 
 | ID | Title | Type | Urgency | Complexity | Risk | Status |
 |----|-------|------|---------|------------|------|--------|
-| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: P2 Dual-AB config batch locally verified; PR/tracker closure pending |
+| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: P2 config-contract batch locally verified; PR/tracker closure pending |
 | p1-stability-batch-1 | PPO/Telemetry Stability Batch 1 | completed-batch | 🔴 critical | M | high | Completed and merged; six bugs closed, broad gates passed |
 | filigree-p0-drain | Critical Filigree P0 Bug Drain | completed-batch | 🔴 critical | L | high | Initial six P0s fixed, verified, and closed |
 | op-value-mismatch | Q(s,op) Double-Sampling Bug | investigation | 🔴 critical | M | high | Diagnosed 2025-12-31, blocks Phase 7. See `docs/bugs/investigations/` |

--- a/docs/plans/ready/2026-06-12-green-state-recovery.md
+++ b/docs/plans/ready/2026-06-12-green-state-recovery.md
@@ -31,11 +31,11 @@ status_notes: >
   Main CI passed on merge commit cdff9c43. Recovery PR #72 landed the initial
   P0 Filigree bug drain and project Filigree install removal. Follow-up PRs
   #78 and #79 merged telemetry and training-control correctness fixes. PRs
-  #80, #81, #82, and #83 merged the first four P2 batches. The repository is
-  green on CI, but not yet steady. The P2 Dual-AB config contract batch is
-  locally fixed and verified against focused tests, custom guardrails, type,
-  lint, full pytest, and Wardline gates.
-percent_complete: 88
+  #80, #81, #82, #83, and #84 merged the first five P2 batches. The repository
+  is green on CI, but not yet steady. The P2 config-contract batch is locally
+  fixed and verified against focused tests, custom/static guardrails, full
+  pytest, and Wardline gates; PR and tracker closure are next.
+percent_complete: 90
 
 reviewed_by:
   - reviewer: python-engineering
@@ -192,13 +192,34 @@ Return the project to a steady state:
   - `MYPYPATH=src uv run mypy -p esper`
   - `uv run pytest` (`4699 passed, 10 skipped, 69 deselected`)
   - `wardline scan . --fail-on ERROR` (`0 active`)
+- PR #84 (`codex/p2-dual-ab-config-contracts`) was merged into `main` on
+  2026-06-12 at merge commit `96df2048d5425949f7bd149f1726a6716096ce07`.
+- PR #84 verification run `27426675468` passed:
+  - `lint`
+  - `typecheck`
+  - `property-tests`
+  - `unit-and-integration-tests`
+  - `e2e-smoke-tests`
+- The P2 Dual-AB config contract bugs were fixed and closed:
+  - `esper-lite-5bc044` Dual-AB config used `.get()` defensive fallback hiding missing keys
+  - `esper-lite-78a856` Dual-AB lacked group_id uniqueness validation allowing silent config collision
+- Local P2 config-contract batch verification on 2026-06-13 passed:
+  - `uv run pytest tests/simic/test_rewards.py::TestContributionRewardComponents::test_advance_from_training_uses_configured_penalty tests/simic/test_config.py::TestTrainingConfigDefaults::test_negative_value_warmup_batches_rejected tests/simic/test_config.py::TestTrainingConfigDefaults::test_zero_value_warmup_batches_disables_warmup -q`
+  - `uv run pytest tests/simic/test_rewards.py tests/simic/test_config.py -q`
+  - `uv run python scripts/lint_defensive_patterns.py`
+  - `uv run python scripts/lint_leyline_types.py`
+  - `uv run python scripts/lint_gpu_sync.py`
+  - `uv run ruff check src/ tests/`
+  - `MYPYPATH=src uv run mypy -p esper`
+  - `uv run pytest` (`4702 passed, 10 skipped, 69 deselected`)
+  - `wardline scan . --fail-on ERROR` (`0 active`)
 - Filigree was removed from the UV tool install on 2026-06-13:
   `uv tool uninstall filigree` removed `filigree`, `filigree-dashboard`,
   `filigree-mcp`, `filigree-scanner-claude`, and `filigree-scanner-codex`.
   `uv tool list` now retains only Legis, Loomweave, Loomweave plugins, and
   Wardline from the local standard tooling set.
-- Filigree on 2026-06-13 reports `11 ready`, `0 blocked`, and `2 wip`
-  after claiming `esper-lite-5bc044` and `esper-lite-78a856`.
+- Filigree on 2026-06-13 reports `9 ready`, `0 blocked`, and `2 wip`
+  after claiming `esper-lite-702e66` and `esper-lite-c8a6df`.
 - Loomweave MCP is visible, but the active MCP server still reports no
   `.weft/loomweave/loomweave.db` even after a worktree analysis pass. The
   available MCP session needs a reconnect before graph queries can be used.

--- a/src/esper/simic/rewards/contribution.py
+++ b/src/esper/simic/rewards/contribution.py
@@ -24,6 +24,7 @@ from .types import (
     STAGE_BLENDING,
     STAGE_FOSSILIZED,
     STAGE_HOLDING,
+    STAGE_TRAINING,
 )
 
 _logger = logging.getLogger(__name__)
@@ -782,6 +783,9 @@ def compute_contribution_reward(
             action_shaping += config.pbrs_weight * pbrs_cull
         action_shaping += _contribution_prune_shaping(seed_info, seed_contribution, config)
         action_shaping += config.prune_cost
+    elif action == LifecycleOp.ADVANCE:
+        if seed_info is not None and seed_info.stage == STAGE_TRAINING:
+            action_shaping += config.advance_from_training_penalty
     elif action == LifecycleOp.SET_ALPHA_TARGET:
         action_shaping += config.set_alpha_target_cost
 

--- a/src/esper/simic/training/config.py
+++ b/src/esper/simic/training/config.py
@@ -417,6 +417,8 @@ class TrainingConfig:
 
         if self.entropy_anneal_episodes < 0:
             raise ValueError("entropy_anneal_episodes cannot be negative")
+        if self.value_warmup_batches < 0:
+            raise ValueError("value_warmup_batches cannot be negative")
 
         if self.max_seeds is not None and self.max_seeds < 1:
             raise ValueError("max_seeds must be >= 1 when provided")

--- a/tests/simic/test_config.py
+++ b/tests/simic/test_config.py
@@ -47,6 +47,16 @@ class TestTrainingConfigDefaults:
         config = TrainingConfig(max_epochs=25, chunk_length=25)
         assert config.chunk_length == 25
 
+    def test_negative_value_warmup_batches_rejected(self):
+        """Negative critic warmup should fail instead of disabling warmup."""
+        with pytest.raises(ValueError, match="value_warmup_batches"):
+            TrainingConfig(value_warmup_batches=-1)
+
+    def test_zero_value_warmup_batches_disables_warmup(self):
+        """Zero remains the explicit switch for disabling critic warmup."""
+        config = TrainingConfig(value_warmup_batches=0)
+        assert config.to_ppo_kwargs()["value_warmup_steps"] == 0
+
 
 class TestTrainingConfigPresets:
     """Tests for TrainingConfig preset helpers."""

--- a/tests/simic/test_rewards.py
+++ b/tests/simic/test_rewards.py
@@ -461,6 +461,35 @@ class TestContributionRewardComponents:
         assert components.alpha_shock == pytest.approx(-0.25)
         assert reward == pytest.approx(components.total_reward)
 
+    def test_advance_from_training_uses_configured_penalty(self):
+        """ADVANCE from TRAINING should apply the declared shaping penalty."""
+        seed_info = SeedInfo(
+            stage=STAGE_TRAINING,
+            improvement_since_stage_start=0.5,
+            total_improvement=0.5,
+            epochs_in_stage=2,
+            seed_params=1000,
+            previous_stage=STAGE_GERMINATED,
+            seed_age_epochs=2,
+        )
+        config = ContributionRewardConfig(advance_from_training_penalty=-0.25)
+
+        _reward, components = compute_contribution_reward(
+            action=LifecycleOp.ADVANCE,
+            seed_contribution=None,
+            val_acc=70.0,
+            seed_info=seed_info,
+            epoch=4,
+            max_epochs=25,
+            total_params=101_000,
+            host_params=100_000,
+            acc_delta=0.0,
+            return_components=True,
+            config=config,
+        )
+
+        assert components.action_shaping == pytest.approx(-0.25)
+
     def test_components_track_context(self):
         """Test that components include action and epoch context."""
         from esper.leyline import SeedStage


### PR DESCRIPTION
## Summary
- apply the declared ADVANCE-from-TRAINING reward shaping penalty
- reject negative value_warmup_batches while preserving zero as the explicit warmup-disable switch
- refresh recovery tracker docs with PR #84 and this batch's local verification evidence

## Verification
- uv run pytest tests/simic/test_rewards.py::TestContributionRewardComponents::test_advance_from_training_uses_configured_penalty tests/simic/test_config.py::TestTrainingConfigDefaults::test_negative_value_warmup_batches_rejected tests/simic/test_config.py::TestTrainingConfigDefaults::test_zero_value_warmup_batches_disables_warmup -q
- uv run pytest tests/simic/test_rewards.py tests/simic/test_config.py -q
- uv run python scripts/lint_defensive_patterns.py
- uv run python scripts/lint_leyline_types.py
- uv run python scripts/lint_gpu_sync.py
- uv run ruff check src/ tests/
- MYPYPATH=src uv run mypy -p esper
- uv run pytest (4702 passed, 10 skipped, 69 deselected)
- wardline scan . --fail-on ERROR (0 active)
