### PR TITLE
fix(simic): harden telemetry contracts

### DIFF
--- a/docs/coord/PLAN_TRACKER.md
+++ b/docs/coord/PLAN_TRACKER.md
@@ -1,6 +1,6 @@
 # Esper Plan Tracker
 
-**Last Updated:** 2026-06-13 (baseline green; P1 follow-up PRs merged; PRs #80/#81/#82/#83/#84 merged; config P2 batch locally verified)
+**Last Updated:** 2026-06-13 (baseline green; P1 follow-up PRs merged; PRs #80/#81/#82/#83/#84/#85 merged; telemetry P2 batch locally verified)
 **Purpose:** Rack-and-stack all plans and concepts for prioritization and dependency tracking.
 
 ---
@@ -21,9 +21,10 @@ P2 contract batch and closed three tracker bugs. PR #81 merged the second P2
 action/reward contract batch and closed two tracker bugs. PR #82 merged the P2
 counterfactual telemetry batch and closed two tracker bugs. PR #83 merged the
 P2 GPU-sync batch and closed two tracker bugs. PR #84 merged the P2 Dual-AB
-config contract batch and closed two tracker bugs. The P2 config-contract batch
-now has local fixes and passing focused/static/full-test/Wardline gates on
-`codex/p2-config-contracts`; PR and tracker closure are next.
+config contract batch and closed two tracker bugs. PR #85 merged the P2
+config-contract batch and closed two tracker bugs. The P2 telemetry-contract
+batch now has local fixes and passing focused/static/full-test/Wardline gates
+on `codex/p2-telemetry-contracts`; PR and tracker closure are next.
 
 ### Post-Hiatus Audit (2026-02-21)
 
@@ -37,7 +38,7 @@ op twice independently — once in `forward()` for value computation, once in `g
 the stored action. These ops frequently diverge, corrupting advantage estimates. Blocks Phase 7.
 
 ### Current Focus Areas
-1. **Green State Recovery** - 🔴 CRITICAL! Baseline green; config P2 batch locally verified
+1. **Green State Recovery** - 🔴 CRITICAL! Baseline green; telemetry P2 batch locally verified
 2. **P1 Stability Batch 1** - ✅ Completed and merged; six high-risk PPO/telemetry correctness bugs closed
 3. **P0 Filigree Bug Drain** - ✅ Initial six P0s fixed and closed
 4. **Op/Value Mismatch** - 🔴 CRITICAL! Fix double-sampling in factored_lstm.py
@@ -74,7 +75,7 @@ the stored action. These ops frequently diverge, corrupting advantage estimates.
 
 | ID | Title | Type | Urgency | Complexity | Risk | Status |
 |----|-------|------|---------|------------|------|--------|
-| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: P2 config-contract batch locally verified; PR/tracker closure pending |
+| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: P2 telemetry-contract batch locally verified; PR/tracker closure pending |
 | p1-stability-batch-1 | PPO/Telemetry Stability Batch 1 | completed-batch | 🔴 critical | M | high | Completed and merged; six bugs closed, broad gates passed |
 | filigree-p0-drain | Critical Filigree P0 Bug Drain | completed-batch | 🔴 critical | L | high | Initial six P0s fixed, verified, and closed |
 | op-value-mismatch | Q(s,op) Double-Sampling Bug | investigation | 🔴 critical | M | high | Diagnosed 2025-12-31, blocks Phase 7. See `docs/bugs/investigations/` |

--- a/docs/plans/ready/2026-06-12-green-state-recovery.md
+++ b/docs/plans/ready/2026-06-12-green-state-recovery.md
@@ -29,13 +29,13 @@ blocks:
 status_notes: >
   PR #52 was made green, accepted, and merged as the new baseline on 2026-06-12.
   Main CI passed on merge commit cdff9c43. Recovery PR #72 landed the initial
-  P0 Filigree bug drain and project Filigree install removal. Follow-up PRs
-  #78 and #79 merged telemetry and training-control correctness fixes. PRs
-  #80, #81, #82, #83, and #84 merged the first five P2 batches. The repository
-  is green on CI, but not yet steady. The P2 config-contract batch is locally
-  fixed and verified against focused tests, custom/static guardrails, full
-  pytest, and Wardline gates; PR and tracker closure are next.
-percent_complete: 90
+  P0 Filigree bug drain. Follow-up PRs #78 and #79 merged telemetry and
+  training-control correctness fixes. PRs #80, #81, #82, #83, #84, and #85
+  merged the first six P2 batches. The repository is green on CI, but not yet
+  steady. The P2 telemetry-contract batch is locally fixed and verified against
+  focused tests, custom/static guardrails, full pytest, and Wardline gates; PR
+  and tracker closure are next.
+percent_complete: 92
 
 reviewed_by:
   - reviewer: python-engineering
@@ -213,13 +213,32 @@ Return the project to a steady state:
   - `MYPYPATH=src uv run mypy -p esper`
   - `uv run pytest` (`4702 passed, 10 skipped, 69 deselected`)
   - `wardline scan . --fail-on ERROR` (`0 active`)
-- Filigree was removed from the UV tool install on 2026-06-13:
-  `uv tool uninstall filigree` removed `filigree`, `filigree-dashboard`,
-  `filigree-mcp`, `filigree-scanner-claude`, and `filigree-scanner-codex`.
-  `uv tool list` now retains only Legis, Loomweave, Loomweave plugins, and
-  Wardline from the local standard tooling set.
-- Filigree on 2026-06-13 reports `9 ready`, `0 blocked`, and `2 wip`
-  after claiming `esper-lite-702e66` and `esper-lite-c8a6df`.
+- PR #85 (`codex/p2-config-contracts`) was merged into `main` on 2026-06-13
+  at merge commit `2e95e9198a8630688bc3e45c5926c3fec53061d2`.
+- PR #85 verification run `27427700826` passed:
+  - `lint`
+  - `typecheck`
+  - `property-tests`
+  - `unit-and-integration-tests`
+  - `e2e-smoke-tests`
+- The P2 config-contract bugs were fixed and closed:
+  - `esper-lite-702e66` advance-from-training reward penalty was configured but not applied
+  - `esper-lite-c8a6df` negative `value_warmup_batches` bypassed config validation
+- Local P2 telemetry-contract batch verification on 2026-06-13 passed:
+  - `uv run pytest tests/simic/test_vectorized.py::test_masked_op_probs_for_telemetry_excludes_invalid_ops tests/simic/test_vectorized.py::test_masked_op_probs_for_telemetry_applies_op_probability_floor tests/simic/test_telemetry_config.py::TestTelemetryConfig::test_should_collect_rejects_unknown_category tests/simic/test_ratio_explosion.py::TestRatioExplosionDiagnostic::test_from_batch_signature_has_no_reserved_dead_parameters -q`
+  - `uv run pytest tests/simic/test_vectorized.py tests/simic/test_telemetry_config.py tests/simic/test_ratio_explosion.py tests/simic/test_debug_telemetry.py -q`
+  - `uv run python scripts/lint_defensive_patterns.py`
+  - `uv run python scripts/lint_leyline_types.py`
+  - `uv run python scripts/lint_gpu_sync.py`
+  - `uv run ruff check src/ tests/`
+  - `MYPYPATH=src uv run mypy -p esper`
+  - `uv run pytest` (`4706 passed, 10 skipped, 69 deselected`)
+  - `wardline scan . --fail-on ERROR` (`0 active`)
+- Filigree remains an installed server-side utility and is not a removal target
+  for this recovery program. Use it only as needed for tracker workflow.
+- Filigree on 2026-06-13 reports `6 ready`, `0 blocked`, and `3 fixing`
+  after claiming `esper-lite-a402a5`, `esper-lite-157dbe`, and
+  `esper-lite-2bcb91`.
 - Loomweave MCP is visible, but the active MCP server still reports no
   `.weft/loomweave/loomweave.db` even after a worktree analysis pass. The
   available MCP session needs a reconnect before graph queries can be used.
@@ -481,24 +500,22 @@ uv run pytest
 
 Current queue snapshot, 2026-06-13:
 
-- P2 ready bugs: 19
-- P3 ready bugs: 2
+- Ready bugs: 6
 - Blocked: 0
-- WIP: 0
+- WIP: 3
 
 Current local batch:
 
-1. `esper-lite-aa2a27` checkpoint load fallback/legacy filtering.
-2. `esper-lite-dcb298` PPO update metrics TypedDict drift.
-3. `esper-lite-860e79` finiteness gate failure list type preservation.
+1. `esper-lite-a402a5` decision telemetry uses unmasked op probabilities.
+2. `esper-lite-157dbe` telemetry `should_collect()` silently disables unknown categories.
+3. `esper-lite-2bcb91` ratio-explosion diagnostic accepts dead reserved parameters.
 
-These all affect typed training/checkpoint/telemetry contracts and should be
-verified together with checkpoint, PPO metric, defensive-pattern, type, and
-full default pytest gates.
+These all affect telemetry contracts and should be verified together with
+focused telemetry/vectorized suites, defensive-pattern, GPU-sync, type, full
+default pytest, and Wardline gates.
 
-Status: fixed and locally verified on branch `codex/p2-steady-state-drain`.
-Tracker closure remains pending because the Filigree UV tool install was
-removed and no writable Filigree MCP tool is currently exposed in this session.
+Status: fixed and locally verified on branch `codex/p2-telemetry-contracts`.
+PR and tracker closure are next.
 
 ## Execution Log
 
@@ -513,8 +530,13 @@ removed and no writable Filigree MCP tool is currently exposed in this session.
 - 2026-06-12: PR #79 merged training-control correctness fixes and closed
   `esper-lite-afaf1a`, `esper-lite-df2f30`, and `esper-lite-6cc6b6`.
 - 2026-06-13: Recovery plan refreshed for the remaining P2/P3 contract drain.
-- 2026-06-13: Removed Filigree from the UV tool install; Legis, Loomweave, and
-  Wardline remain installed as UV tools.
 - 2026-06-13: Locally fixed and verified P2 contract batch
-  `esper-lite-aa2a27`, `esper-lite-dcb298`, and `esper-lite-860e79`; tracker
-  closure is pending a writable Filigree surface.
+  `esper-lite-aa2a27`, `esper-lite-dcb298`, and `esper-lite-860e79`; PR #80
+  merged and tracker closure completed.
+- 2026-06-13: Left the installed Filigree server utility alone; it is not part
+  of the recovery removal scope.
+- 2026-06-13: PRs #81, #82, #83, #84, and #85 merged five more P2 batches,
+  closing ten additional tracker bugs.
+- 2026-06-13: Locally fixed and verified P2 telemetry-contract batch
+  `esper-lite-a402a5`, `esper-lite-157dbe`, and `esper-lite-2bcb91`; PR and
+  tracker closure are next.

--- a/src/esper/simic/telemetry/debug_telemetry.py
+++ b/src/esper/simic/telemetry/debug_telemetry.py
@@ -323,8 +323,6 @@ class RatioExplosionDiagnostic:
         actions: "torch.Tensor",
         max_threshold: float = 5.0,
         min_threshold: float = 0.1,
-        states: "torch.Tensor | None" = None,
-        action_masks: "torch.Tensor | None" = None,
     ) -> "RatioExplosionDiagnostic":
         """Create diagnostic from batch tensors.
 
@@ -335,8 +333,6 @@ class RatioExplosionDiagnostic:
             actions: Actions taken [N]
             max_threshold: Ratio above this is problematic
             min_threshold: Ratio below this is problematic
-            states: State observations [N, state_dim] (unused, reserved for future)
-            action_masks: Valid action masks [N, action_dim] (unused, reserved for future)
 
         Returns:
             RatioExplosionDiagnostic

--- a/src/esper/simic/telemetry/telemetry_config.py
+++ b/src/esper/simic/telemetry/telemetry_config.py
@@ -72,7 +72,7 @@ class TelemetryConfig:
             return level >= TelemetryLevel.NORMAL
         elif category == "debug":
             return level >= TelemetryLevel.DEBUG
-        return False
+        raise ValueError(f"Unknown telemetry category: {category}")
 
     def escalate_temporarily(self, epochs: int | None = None) -> None:
         """Temporarily escalate to DEBUG level.

--- a/src/esper/simic/training/vectorized_trainer.py
+++ b/src/esper/simic/training/vectorized_trainer.py
@@ -29,7 +29,11 @@ from esper.simic.telemetry import (
 )
 from esper.simic.telemetry.emitters import check_performance_degradation
 from esper.simic.rewards import ContributionRewardInputs, LossRewardInputs
-from esper.tamiyo.policy.action_masks import build_slot_states, compute_action_masks
+from esper.tamiyo.policy.action_masks import (
+    MaskedCategorical,
+    build_slot_states,
+    compute_action_masks,
+)
 from esper.tamiyo.policy.features import batch_obs_to_features
 from esper.utils.data import augment_cifar10_batch
 
@@ -72,6 +76,19 @@ def _pair_index_accs_for_active_slots(
         (slot_to_index[slot_a], slot_to_index[slot_b]): pair_acc
         for (slot_a, slot_b), pair_acc in pair_accs_by_slot.items()
     }
+
+
+def _masked_op_probs_for_telemetry(
+    *,
+    op_logits: torch.Tensor,
+    op_mask: torch.Tensor,
+    probability_floor: dict[str, float] | None,
+) -> torch.Tensor:
+    """Return op probabilities using the same mask/floor contract as action sampling."""
+    op_min_prob = None
+    if probability_floor is not None and "op" in probability_floor:
+        op_min_prob = probability_floor["op"]
+    return MaskedCategorical(op_logits, op_mask, min_prob=op_min_prob).probs
 
 
 @dataclass
@@ -1395,8 +1412,12 @@ class VectorizedPPOTrainer:
                     # per step instead of 1. This was the root cause of 90% throughput drop.
                     op_probs_cpu: np.ndarray | None = None
                     if ops_telemetry_enabled and action_result.op_logits is not None:
-                        # Batch softmax over all envs, single GPU->CPU transfer
-                        op_probs_all = torch.softmax(action_result.op_logits, dim=-1)
+                        # Batch masked distribution over all envs, single GPU->CPU transfer.
+                        op_probs_all = _masked_op_probs_for_telemetry(
+                            op_logits=action_result.op_logits,
+                            op_mask=masks_batch["op"],
+                            probability_floor=agent.probability_floor,
+                        )
                         op_probs_cpu = op_probs_all.cpu().numpy()
 
                     # PERF: Pre-compute per-head confidences AND entropy for telemetry.

--- a/tests/simic/test_ratio_explosion.py
+++ b/tests/simic/test_ratio_explosion.py
@@ -1,5 +1,7 @@
 """Tests for ratio explosion diagnostics."""
 
+import inspect
+
 import torch
 
 from esper.simic.telemetry import RatioExplosionDiagnostic
@@ -14,9 +16,7 @@ class TestRatioExplosionDiagnostic:
         ratio = torch.tensor([0.5, 1.0, 1.5, 6.0, 0.05])
         old_log_probs = torch.tensor([-1.0, -0.5, -0.8, -0.3, -2.0])
         new_log_probs = torch.tensor([-1.2, -0.5, -0.4, 1.5, -5.0])
-        states = torch.randn(5, 10)
         actions = torch.tensor([0, 1, 2, 1, 0])
-        action_masks = torch.ones(5, 4)
 
         diag = RatioExplosionDiagnostic.from_batch(
             ratio=ratio,
@@ -25,12 +25,17 @@ class TestRatioExplosionDiagnostic:
             actions=actions,
             max_threshold=5.0,
             min_threshold=0.1,
-            states=states,
-            action_masks=action_masks,
         )
 
         assert len(diag.worst_ratio_indices) == 2  # 6.0 > 5.0, 0.05 < 0.1
         assert diag.logit_diff_max > 0
+
+    def test_from_batch_signature_has_no_reserved_dead_parameters(self):
+        """from_batch should not accept unused states/action_masks parameters."""
+        parameters = inspect.signature(RatioExplosionDiagnostic.from_batch).parameters
+
+        assert "states" not in parameters
+        assert "action_masks" not in parameters
 
     def test_to_dict_serializable(self):
         """Diagnostic can be serialized to dict."""

--- a/tests/simic/test_telemetry_config.py
+++ b/tests/simic/test_telemetry_config.py
@@ -1,6 +1,8 @@
 """Tests for telemetry configuration."""
 
 
+import pytest
+
 from esper.simic.telemetry import TelemetryLevel, TelemetryConfig
 
 
@@ -69,3 +71,9 @@ class TestTelemetryConfig:
         config = TelemetryConfig(level=TelemetryLevel.MINIMAL)
         assert config.should_collect("ops_normal") is False
         assert config.should_collect("debug") is False
+
+    def test_should_collect_rejects_unknown_category(self):
+        """Unknown telemetry categories should fail instead of silently disabling."""
+        config = TelemetryConfig(level=TelemetryLevel.DEBUG)
+        with pytest.raises(ValueError, match="Unknown telemetry category"):
+            config.should_collect("new_category")

--- a/tests/simic/test_vectorized.py
+++ b/tests/simic/test_vectorized.py
@@ -24,6 +24,7 @@ from esper.simic.training.vectorized import (
     _run_ppo_updates,
 )
 from esper.simic.training.vectorized_trainer import (
+    _masked_op_probs_for_telemetry,
     _pair_index_accs_for_active_slots,
     _pair_slot_key,
 )
@@ -60,6 +61,39 @@ def test_pair_attribution_keys_survive_non_lexicographic_slot_order():
     )
 
     assert emitter_pair_accs == {(2, 1): 47.0}
+
+
+def test_masked_op_probs_for_telemetry_excludes_invalid_ops():
+    """Decision telemetry op probabilities should be normalized over valid ops."""
+    logits = torch.tensor([[5.0, 4.0, 3.0, 2.0, 1.0, 0.0]])
+    mask = torch.tensor([[True, False, True, False, False, False]])
+
+    probs = _masked_op_probs_for_telemetry(
+        op_logits=logits,
+        op_mask=mask,
+        probability_floor=None,
+    )
+
+    assert probs[0, 1] == pytest.approx(0.0)
+    assert probs[0, 3] == pytest.approx(0.0)
+    assert probs[0, 4] == pytest.approx(0.0)
+    assert probs[0, 5] == pytest.approx(0.0)
+    assert probs[0, 0] + probs[0, 2] == pytest.approx(1.0)
+
+
+def test_masked_op_probs_for_telemetry_applies_op_probability_floor():
+    """Decision telemetry should match the policy's op probability floor."""
+    logits = torch.tensor([[10.0, 0.0, -10.0]])
+    mask = torch.tensor([[True, True, True]])
+
+    probs = _masked_op_probs_for_telemetry(
+        op_logits=logits,
+        op_mask=mask,
+        probability_floor={"op": 0.2},
+    )
+
+    assert probs.sum().item() == pytest.approx(1.0)
+    assert probs.min().item() >= 0.2 - 1e-6
 
 
 def test_lifecycle_only_keeps_slot_telemetry():


### PR DESCRIPTION
## Summary
- compute decision telemetry op probabilities through the masked/floored policy distribution instead of a raw softmax
- make unknown telemetry categories fail fast in `TelemetryConfig.should_collect()`
- remove dead reserved parameters from `RatioExplosionDiagnostic.from_batch()`
- update recovery plan/tracker status for PR #85, the current telemetry batch, and the Filigree utility boundary

## Verification
- `uv run pytest tests/simic/test_vectorized.py::test_masked_op_probs_for_telemetry_excludes_invalid_ops tests/simic/test_vectorized.py::test_masked_op_probs_for_telemetry_applies_op_probability_floor tests/simic/test_telemetry_config.py::TestTelemetryConfig::test_should_collect_rejects_unknown_category tests/simic/test_ratio_explosion.py::TestRatioExplosionDiagnostic::test_from_batch_signature_has_no_reserved_dead_parameters -q`
- `uv run pytest tests/simic/test_vectorized.py tests/simic/test_telemetry_config.py tests/simic/test_ratio_explosion.py tests/simic/test_debug_telemetry.py -q`
- `uv run python scripts/lint_defensive_patterns.py`
- `uv run python scripts/lint_leyline_types.py`
- `uv run python scripts/lint_gpu_sync.py`
- `uv run ruff check src/ tests/`
- `MYPYPATH=src uv run mypy -p esper`
- `uv run pytest` (`4706 passed, 10 skipped, 69 deselected`)
- `wardline scan . --fail-on ERROR` (`0 active`)

Tracked issues: `esper-lite-a402a5`, `esper-lite-157dbe`, `esper-lite-2bcb91`