### PR TITLE
fix(simic): lazy load import hygiene exports

### DIFF
--- a/docs/coord/PLAN_TRACKER.md
+++ b/docs/coord/PLAN_TRACKER.md
@@ -1,6 +1,6 @@
 # Esper Plan Tracker
 
-**Last Updated:** 2026-06-13 (baseline green; P1 follow-up PRs merged; PRs #80/#81/#82/#83/#84/#85 merged; telemetry P2 batch locally verified)
+**Last Updated:** 2026-06-13 (baseline green; P1 follow-up PRs merged; PRs #80-#86 merged; import-hygiene batch locally verified)
 **Purpose:** Rack-and-stack all plans and concepts for prioritization and dependency tracking.
 
 ---
@@ -22,9 +22,10 @@ action/reward contract batch and closed two tracker bugs. PR #82 merged the P2
 counterfactual telemetry batch and closed two tracker bugs. PR #83 merged the
 P2 GPU-sync batch and closed two tracker bugs. PR #84 merged the P2 Dual-AB
 config contract batch and closed two tracker bugs. PR #85 merged the P2
-config-contract batch and closed two tracker bugs. The P2 telemetry-contract
+config-contract batch and closed two tracker bugs. PR #86 merged the P2
+telemetry-contract batch and closed three tracker bugs. The import-hygiene
 batch now has local fixes and passing focused/static/full-test/Wardline gates
-on `codex/p2-telemetry-contracts`; PR and tracker closure are next.
+on `codex/p2-import-hygiene`; PR and tracker closure are next.
 
 ### Post-Hiatus Audit (2026-02-21)
 
@@ -38,7 +39,7 @@ op twice independently — once in `forward()` for value computation, once in `g
 the stored action. These ops frequently diverge, corrupting advantage estimates. Blocks Phase 7.
 
 ### Current Focus Areas
-1. **Green State Recovery** - 🔴 CRITICAL! Baseline green; telemetry P2 batch locally verified
+1. **Green State Recovery** - 🔴 CRITICAL! Baseline green; import-hygiene batch locally verified
 2. **P1 Stability Batch 1** - ✅ Completed and merged; six high-risk PPO/telemetry correctness bugs closed
 3. **P0 Filigree Bug Drain** - ✅ Initial six P0s fixed and closed
 4. **Op/Value Mismatch** - 🔴 CRITICAL! Fix double-sampling in factored_lstm.py
@@ -75,7 +76,7 @@ the stored action. These ops frequently diverge, corrupting advantage estimates.
 
 | ID | Title | Type | Urgency | Complexity | Risk | Status |
 |----|-------|------|---------|------------|------|--------|
-| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: P2 telemetry-contract batch locally verified; PR/tracker closure pending |
+| green-state-recovery-2026-06-12 | Green State Recovery Program | in-progress | 🔴 critical | M | high | Active: import-hygiene batch locally verified; PR/tracker closure pending |
 | p1-stability-batch-1 | PPO/Telemetry Stability Batch 1 | completed-batch | 🔴 critical | M | high | Completed and merged; six bugs closed, broad gates passed |
 | filigree-p0-drain | Critical Filigree P0 Bug Drain | completed-batch | 🔴 critical | L | high | Initial six P0s fixed, verified, and closed |
 | op-value-mismatch | Q(s,op) Double-Sampling Bug | investigation | 🔴 critical | M | high | Diagnosed 2025-12-31, blocks Phase 7. See `docs/bugs/investigations/` |

--- a/docs/plans/ready/2026-06-12-green-state-recovery.md
+++ b/docs/plans/ready/2026-06-12-green-state-recovery.md
@@ -30,12 +30,12 @@ status_notes: >
   PR #52 was made green, accepted, and merged as the new baseline on 2026-06-12.
   Main CI passed on merge commit cdff9c43. Recovery PR #72 landed the initial
   P0 Filigree bug drain. Follow-up PRs #78 and #79 merged telemetry and
-  training-control correctness fixes. PRs #80, #81, #82, #83, #84, and #85
-  merged the first six P2 batches. The repository is green on CI, but not yet
-  steady. The P2 telemetry-contract batch is locally fixed and verified against
+  training-control correctness fixes. PRs #80, #81, #82, #83, #84, #85, and
+  #86 merged seven P2 batches. The repository is green on CI, but not yet
+  steady. The import-hygiene batch is locally fixed and verified against
   focused tests, custom/static guardrails, full pytest, and Wardline gates; PR
   and tracker closure are next.
-percent_complete: 92
+percent_complete: 94
 
 reviewed_by:
   - reviewer: python-engineering
@@ -234,11 +234,34 @@ Return the project to a steady state:
   - `MYPYPATH=src uv run mypy -p esper`
   - `uv run pytest` (`4706 passed, 10 skipped, 69 deselected`)
   - `wardline scan . --fail-on ERROR` (`0 active`)
+- PR #86 (`codex/p2-telemetry-contracts`) was merged into `main` on
+  2026-06-13 at merge commit `bad835e8`.
+- PR #86 verification run `27428779288` passed:
+  - `lint`
+  - `typecheck`
+  - `property-tests`
+  - `unit-and-integration-tests`
+  - `e2e-smoke-tests`
+- The P2 telemetry-contract bugs were fixed and closed:
+  - `esper-lite-a402a5` decision telemetry used unmasked op probabilities
+  - `esper-lite-157dbe` telemetry `should_collect()` silently disabled unknown categories
+  - `esper-lite-2bcb91` ratio-explosion diagnostic accepted dead reserved parameters
+- Local import-hygiene batch verification on 2026-06-13 passed:
+  - `uv run pytest tests/test_import_isolation.py::test_simic_training_import_does_not_load_parallel_env_state tests/test_import_isolation.py::test_simic_training_parallel_env_state_lazy_attribute_works tests/test_import_isolation.py::test_simic_safe_task_config_resolve_from_leyline_without_tamiyo tests/test_import_isolation.py::test_simic_telemetry_import_isolation tests/test_import_isolation.py::test_simic_telemetry_lazy_attribute_works -q`
+  - `uv run pytest tests/test_import_isolation.py -q`
+  - `uv run pytest tests/simic/test_telemetry_config.py tests/simic/test_debug_telemetry.py tests/simic/test_gradient_collector.py tests/simic/test_anomaly_detector.py tests/simic/test_config.py tests/simic/training/test_config_validation.py -q`
+  - `uv run python scripts/lint_defensive_patterns.py`
+  - `uv run python scripts/lint_leyline_types.py`
+  - `uv run python scripts/lint_gpu_sync.py`
+  - `uv run ruff check src/ tests/`
+  - `MYPYPATH=src uv run mypy -p esper`
+  - `uv run pytest` (`4711 passed, 10 skipped, 69 deselected`)
+  - `wardline scan . --fail-on ERROR` (`0 active`)
 - Filigree remains an installed server-side utility and is not a removal target
   for this recovery program. Use it only as needed for tracker workflow.
-- Filigree on 2026-06-13 reports `6 ready`, `0 blocked`, and `3 fixing`
-  after claiming `esper-lite-a402a5`, `esper-lite-157dbe`, and
-  `esper-lite-2bcb91`.
+- Filigree on 2026-06-13 reports `3 ready`, `0 blocked`, and `3 fixing`
+  after claiming `esper-lite-0c7b3b`, `esper-lite-7481c4`, and
+  `esper-lite-eb5662`.
 - Loomweave MCP is visible, but the active MCP server still reports no
   `.weft/loomweave/loomweave.db` even after a worktree analysis pass. The
   available MCP session needs a reconnect before graph queries can be used.
@@ -500,21 +523,22 @@ uv run pytest
 
 Current queue snapshot, 2026-06-13:
 
-- Ready bugs: 6
+- Ready bugs: 3
 - Blocked: 0
 - WIP: 3
 
 Current local batch:
 
-1. `esper-lite-a402a5` decision telemetry uses unmasked op probabilities.
-2. `esper-lite-157dbe` telemetry `should_collect()` silently disables unknown categories.
-3. `esper-lite-2bcb91` ratio-explosion diagnostic accepts dead reserved parameters.
+1. `esper-lite-0c7b3b` `training/__init__.py` eagerly imports `ParallelEnvState`.
+2. `esper-lite-7481c4` `simic.__getattr__` resolves `safe` and `TaskConfig` through Tamiyo.
+3. `esper-lite-eb5662` `telemetry/__init__.py` eagerly imports heavy telemetry modules.
 
-These all affect telemetry contracts and should be verified together with
-focused telemetry/vectorized suites, defensive-pattern, GPU-sync, type, full
-default pytest, and Wardline gates.
+These all affect import hygiene and package-level public exports. They should
+be verified together with import-isolation tests, telemetry/config import
+consumers, defensive-pattern, GPU-sync, type, full default pytest, and Wardline
+gates.
 
-Status: fixed and locally verified on branch `codex/p2-telemetry-contracts`.
+Status: fixed and locally verified on branch `codex/p2-import-hygiene`.
 PR and tracker closure are next.
 
 ## Execution Log
@@ -538,5 +562,8 @@ PR and tracker closure are next.
 - 2026-06-13: PRs #81, #82, #83, #84, and #85 merged five more P2 batches,
   closing ten additional tracker bugs.
 - 2026-06-13: Locally fixed and verified P2 telemetry-contract batch
-  `esper-lite-a402a5`, `esper-lite-157dbe`, and `esper-lite-2bcb91`; PR and
+  `esper-lite-a402a5`, `esper-lite-157dbe`, and `esper-lite-2bcb91`; PR #86
+  merged and tracker closure completed.
+- 2026-06-13: Locally fixed and verified import-hygiene batch
+  `esper-lite-0c7b3b`, `esper-lite-7481c4`, and `esper-lite-eb5662`; PR and
   tracker closure are next.

--- a/src/esper/simic/__init__.py
+++ b/src/esper/simic/__init__.py
@@ -90,13 +90,15 @@ def __getattr__(name: str) -> Any:
     Heavy modules (tamiyo policy features/masks with torch, telemetry with torch,
     training loops) are only loaded when accessed, not at package import time.
     """
-    # Features (HEAVY - from tamiyo.policy which loads torch)
+    # Lightweight feature contracts from leyline.
     if name in ("safe", "TaskConfig"):
-        from esper.tamiyo.policy.features import safe, TaskConfig
+        from esper.leyline import safe, TaskConfig
+
         mapping: dict[str, Any] = {
             "safe": safe,
             "TaskConfig": TaskConfig,
         }
+        globals().update(mapping)
         return mapping[name]
 
     # Action Masks (HEAVY - from tamiyo.policy which loads torch)

--- a/src/esper/simic/telemetry/__init__.py
+++ b/src/esper/simic/telemetry/__init__.py
@@ -8,77 +8,60 @@ This package contains:
 - anomaly_detector.py: Phase-dependent training anomaly detection
 """
 
-# Telemetry configuration
-from .telemetry_config import (
-    TelemetryLevel,
-    TelemetryConfig,
-)
+from typing import TYPE_CHECKING, Any
+import importlib
 
-# Debug telemetry (per-layer gradients)
-from .debug_telemetry import (
-    LayerGradientStats,
-    collect_per_layer_gradients,
-    NumericalStabilityReport,
-    check_numerical_stability,
-    RatioExplosionDiagnostic,
-)
-
-# Gradient collection
-from .gradient_collector import (
-    GradientHealthMetrics,
-    DualGradientStats,
-    SeedGradientCollector,
-    collect_dual_gradients_async,
-    collect_host_gradients_async,
-    collect_seed_gradients_only_async,
-    materialize_dual_grad_stats,
-    materialize_grad_stats,
-    collect_seed_gradients,
-    collect_seed_gradients_async,
-)
-
-# Anomaly detection
-from .anomaly_detector import (
-    AnomalyDetector,
-    AnomalyReport,
-)
-
-# LSTM health monitoring (P4-8)
-from .lstm_health import (
-    LSTMHealthMetrics,
-    compute_lstm_health,
-)
-
-# Gradient EMA drift detection (P4-9)
-from .gradient_ema import GradientEMATracker
-
-# torch.profiler integration (P4-5)
-from .profiler import training_profiler
-
-# Telemetry emitters (pure functions)
-from .emitters import (
-    emit_with_env_context,
-    emit_batch_completed,
-    emit_last_action,
-    compute_grad_norm_surrogate,
-    aggregate_layer_gradient_health,
-    emit_ppo_update_event,
-    emit_action_distribution,
-    emit_throughput,
-    emit_reward_summary,
-    emit_mask_hit_rates,
-    check_performance_degradation,
-    apply_slot_telemetry,
-)
-
-# Value function metrics (TELE-220 to TELE-228)
-from esper.leyline.value_metrics import (
-    compute_value_function_metrics,
-    ValueFunctionMetricsDict,
-)
-
-# Observation statistics (TELE-OBS)
-from .observation_stats import ObservationStatsTelemetry, compute_observation_stats
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    # Config
+    "TelemetryLevel": ("esper.simic.telemetry.telemetry_config", "TelemetryLevel"),
+    "TelemetryConfig": ("esper.simic.telemetry.telemetry_config", "TelemetryConfig"),
+    # Debug telemetry
+    "LayerGradientStats": ("esper.simic.telemetry.debug_telemetry", "LayerGradientStats"),
+    "collect_per_layer_gradients": ("esper.simic.telemetry.debug_telemetry", "collect_per_layer_gradients"),
+    "NumericalStabilityReport": ("esper.simic.telemetry.debug_telemetry", "NumericalStabilityReport"),
+    "check_numerical_stability": ("esper.simic.telemetry.debug_telemetry", "check_numerical_stability"),
+    "RatioExplosionDiagnostic": ("esper.simic.telemetry.debug_telemetry", "RatioExplosionDiagnostic"),
+    # Gradient collection
+    "GradientHealthMetrics": ("esper.simic.telemetry.gradient_collector", "GradientHealthMetrics"),
+    "DualGradientStats": ("esper.simic.telemetry.gradient_collector", "DualGradientStats"),
+    "SeedGradientCollector": ("esper.simic.telemetry.gradient_collector", "SeedGradientCollector"),
+    "collect_dual_gradients_async": ("esper.simic.telemetry.gradient_collector", "collect_dual_gradients_async"),
+    "collect_host_gradients_async": ("esper.simic.telemetry.gradient_collector", "collect_host_gradients_async"),
+    "collect_seed_gradients_only_async": ("esper.simic.telemetry.gradient_collector", "collect_seed_gradients_only_async"),
+    "materialize_dual_grad_stats": ("esper.simic.telemetry.gradient_collector", "materialize_dual_grad_stats"),
+    "materialize_grad_stats": ("esper.simic.telemetry.gradient_collector", "materialize_grad_stats"),
+    "collect_seed_gradients": ("esper.simic.telemetry.gradient_collector", "collect_seed_gradients"),
+    "collect_seed_gradients_async": ("esper.simic.telemetry.gradient_collector", "collect_seed_gradients_async"),
+    # Anomaly detection
+    "AnomalyDetector": ("esper.simic.telemetry.anomaly_detector", "AnomalyDetector"),
+    "AnomalyReport": ("esper.simic.telemetry.anomaly_detector", "AnomalyReport"),
+    # LSTM health monitoring (P4-8)
+    "LSTMHealthMetrics": ("esper.simic.telemetry.lstm_health", "LSTMHealthMetrics"),
+    "compute_lstm_health": ("esper.simic.telemetry.lstm_health", "compute_lstm_health"),
+    # Gradient EMA drift detection (P4-9)
+    "GradientEMATracker": ("esper.simic.telemetry.gradient_ema", "GradientEMATracker"),
+    # torch.profiler integration (P4-5)
+    "training_profiler": ("esper.simic.telemetry.profiler", "training_profiler"),
+    # Telemetry emitters
+    "emit_with_env_context": ("esper.simic.telemetry.emitters", "emit_with_env_context"),
+    "emit_batch_completed": ("esper.simic.telemetry.emitters", "emit_batch_completed"),
+    "emit_last_action": ("esper.simic.telemetry.emitters", "emit_last_action"),
+    "compute_grad_norm_surrogate": ("esper.simic.telemetry.emitters", "compute_grad_norm_surrogate"),
+    "aggregate_layer_gradient_health": ("esper.simic.telemetry.emitters", "aggregate_layer_gradient_health"),
+    "emit_ppo_update_event": ("esper.simic.telemetry.emitters", "emit_ppo_update_event"),
+    "emit_action_distribution": ("esper.simic.telemetry.emitters", "emit_action_distribution"),
+    "emit_throughput": ("esper.simic.telemetry.emitters", "emit_throughput"),
+    "emit_reward_summary": ("esper.simic.telemetry.emitters", "emit_reward_summary"),
+    "emit_mask_hit_rates": ("esper.simic.telemetry.emitters", "emit_mask_hit_rates"),
+    "check_performance_degradation": ("esper.simic.telemetry.emitters", "check_performance_degradation"),
+    "apply_slot_telemetry": ("esper.simic.telemetry.emitters", "apply_slot_telemetry"),
+    # Value function metrics (TELE-220 to TELE-228)
+    "compute_value_function_metrics": ("esper.leyline.value_metrics", "compute_value_function_metrics"),
+    "ValueFunctionMetricsDict": ("esper.leyline.value_metrics", "ValueFunctionMetricsDict"),
+    # Observation statistics (TELE-OBS)
+    "ObservationStatsTelemetry": ("esper.simic.telemetry.observation_stats", "ObservationStatsTelemetry"),
+    "compute_observation_stats": ("esper.simic.telemetry.observation_stats", "compute_observation_stats"),
+}
 
 __all__ = [
     # Config
@@ -131,3 +114,76 @@ __all__ = [
     "ObservationStatsTelemetry",
     "compute_observation_stats",
 ]
+
+if TYPE_CHECKING:
+    from esper.leyline.value_metrics import (
+        ValueFunctionMetricsDict as ValueFunctionMetricsDict,
+        compute_value_function_metrics as compute_value_function_metrics,
+    )
+    from esper.simic.telemetry.anomaly_detector import (
+        AnomalyDetector as AnomalyDetector,
+        AnomalyReport as AnomalyReport,
+    )
+    from esper.simic.telemetry.debug_telemetry import (
+        LayerGradientStats as LayerGradientStats,
+        NumericalStabilityReport as NumericalStabilityReport,
+        RatioExplosionDiagnostic as RatioExplosionDiagnostic,
+        check_numerical_stability as check_numerical_stability,
+        collect_per_layer_gradients as collect_per_layer_gradients,
+    )
+    from esper.simic.telemetry.emitters import (
+        aggregate_layer_gradient_health as aggregate_layer_gradient_health,
+        apply_slot_telemetry as apply_slot_telemetry,
+        check_performance_degradation as check_performance_degradation,
+        compute_grad_norm_surrogate as compute_grad_norm_surrogate,
+        emit_action_distribution as emit_action_distribution,
+        emit_batch_completed as emit_batch_completed,
+        emit_last_action as emit_last_action,
+        emit_mask_hit_rates as emit_mask_hit_rates,
+        emit_ppo_update_event as emit_ppo_update_event,
+        emit_reward_summary as emit_reward_summary,
+        emit_throughput as emit_throughput,
+        emit_with_env_context as emit_with_env_context,
+    )
+    from esper.simic.telemetry.gradient_collector import (
+        DualGradientStats as DualGradientStats,
+        GradientHealthMetrics as GradientHealthMetrics,
+        SeedGradientCollector as SeedGradientCollector,
+        collect_dual_gradients_async as collect_dual_gradients_async,
+        collect_host_gradients_async as collect_host_gradients_async,
+        collect_seed_gradients as collect_seed_gradients,
+        collect_seed_gradients_async as collect_seed_gradients_async,
+        collect_seed_gradients_only_async as collect_seed_gradients_only_async,
+        materialize_dual_grad_stats as materialize_dual_grad_stats,
+        materialize_grad_stats as materialize_grad_stats,
+    )
+    from esper.simic.telemetry.gradient_ema import GradientEMATracker as GradientEMATracker
+    from esper.simic.telemetry.lstm_health import (
+        LSTMHealthMetrics as LSTMHealthMetrics,
+        compute_lstm_health as compute_lstm_health,
+    )
+    from esper.simic.telemetry.observation_stats import (
+        ObservationStatsTelemetry as ObservationStatsTelemetry,
+        compute_observation_stats as compute_observation_stats,
+    )
+    from esper.simic.telemetry.profiler import training_profiler as training_profiler
+    from esper.simic.telemetry.telemetry_config import (
+        TelemetryConfig as TelemetryConfig,
+        TelemetryLevel as TelemetryLevel,
+    )
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy import telemetry exports and cache them on first access."""
+    if name in _LAZY_IMPORTS:
+        module_path, attr_name = _LAZY_IMPORTS[name]
+        module = importlib.import_module(module_path)
+        value = module.__dict__[attr_name]
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Expose the telemetry public API without importing heavy modules."""
+    return sorted(set(globals().keys()) | set(__all__))

--- a/src/esper/simic/training/__init__.py
+++ b/src/esper/simic/training/__init__.py
@@ -17,11 +17,14 @@ Lightweight helpers should also be imported directly to avoid circular imports:
     from esper.simic.training.helpers import train_heuristic, run_heuristic_episode
 """
 
-from .parallel_env_state import ParallelEnvState
+from typing import TYPE_CHECKING, Any
 
 from .config import TrainingConfig
 
 from esper.simic.vectorized_types import EpisodeRecord
+
+if TYPE_CHECKING:
+    from .parallel_env_state import ParallelEnvState as ParallelEnvState
 
 # NOTE: vectorized and dual_ab are NOT imported here to avoid import-time side effects
 # Import them explicitly when needed
@@ -37,3 +40,18 @@ __all__ = [
     # "train_ppo_vectorized",  # from .vectorized
     # "train_dual_policy_ab",  # from .dual_ab
 ]
+
+
+def __getattr__(name: str) -> Any:
+    """Lazy import training exports that pull heavy runtime dependencies."""
+    if name == "ParallelEnvState":
+        from .parallel_env_state import ParallelEnvState
+
+        globals()["ParallelEnvState"] = ParallelEnvState
+        return ParallelEnvState
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__() -> list[str]:
+    """Expose the public training API without importing heavy modules."""
+    return sorted(set(globals().keys()) | set(__all__))

--- a/tests/test_import_isolation.py
+++ b/tests/test_import_isolation.py
@@ -143,6 +143,137 @@ print(json.dumps({
     assert result["vectorized_loaded"] is True
 
 
+def test_simic_training_import_does_not_load_parallel_env_state():
+    """Importing esper.simic.training should not load heavy env state machinery."""
+    result = _run_isolated(
+        """
+import json
+import sys
+
+import esper.simic.training
+
+print(json.dumps({
+    "torch_loaded": "torch" in sys.modules,
+    "parallel_env_state_loaded": "esper.simic.training.parallel_env_state" in sys.modules,
+    "ParallelEnvState_in_dir": "ParallelEnvState" in dir(esper.simic.training),
+}))
+""".strip()
+    )
+
+    assert result["torch_loaded"] is False
+    assert result["parallel_env_state_loaded"] is False
+    assert result["ParallelEnvState_in_dir"] is True
+
+
+def test_simic_training_parallel_env_state_lazy_attribute_works():
+    """ParallelEnvState should load only when the public attribute is accessed."""
+    result = _run_isolated(
+        """
+import json
+import sys
+
+import esper.simic.training
+from esper.simic.training import ParallelEnvState
+
+print(json.dumps({
+    "is_class": str(type(ParallelEnvState)),
+    "cached": "ParallelEnvState" in vars(esper.simic.training),
+    "parallel_env_state_loaded": "esper.simic.training.parallel_env_state" in sys.modules,
+    "torch_loaded": "torch" in sys.modules,
+}))
+""".strip()
+    )
+
+    assert "type" in result["is_class"]
+    assert result["cached"] is True
+    assert result["parallel_env_state_loaded"] is True
+    assert result["torch_loaded"] is True
+
+
+def test_simic_safe_task_config_resolve_from_leyline_without_tamiyo():
+    """safe and TaskConfig should not route through Tamiyo's heavy policy module."""
+    result = _run_isolated(
+        """
+import json
+import sys
+
+import esper.simic
+from esper.simic import TaskConfig, safe
+
+print(json.dumps({
+    "safe_result": safe(None, 3.0),
+    "task_config_module": TaskConfig.__module__,
+    "cached_safe": "safe" in vars(esper.simic),
+    "cached_task_config": "TaskConfig" in vars(esper.simic),
+    "tamiyo_features_loaded": "esper.tamiyo.policy.features" in sys.modules,
+    "torch_loaded": "torch" in sys.modules,
+}))
+""".strip()
+    )
+
+    assert result["safe_result"] == 3.0
+    assert result["task_config_module"] == "esper.leyline.task_config"
+    assert result["cached_safe"] is True
+    assert result["cached_task_config"] is True
+    assert result["tamiyo_features_loaded"] is False
+    assert result["torch_loaded"] is False
+
+
+def test_simic_telemetry_import_isolation():
+    """Importing telemetry should not eagerly load heavy collectors and emitters."""
+    result = _run_isolated(
+        """
+import json
+import sys
+
+import esper.simic.telemetry
+
+print(json.dumps({
+    "torch_loaded": "torch" in sys.modules,
+    "debug_loaded": "esper.simic.telemetry.debug_telemetry" in sys.modules,
+    "gradient_collector_loaded": "esper.simic.telemetry.gradient_collector" in sys.modules,
+    "emitters_loaded": "esper.simic.telemetry.emitters" in sys.modules,
+    "RatioExplosionDiagnostic_in_dir": "RatioExplosionDiagnostic" in dir(esper.simic.telemetry),
+}))
+""".strip()
+    )
+
+    assert result["torch_loaded"] is False
+    assert result["debug_loaded"] is False
+    assert result["gradient_collector_loaded"] is False
+    assert result["emitters_loaded"] is False
+    assert result["RatioExplosionDiagnostic_in_dir"] is True
+
+
+def test_simic_telemetry_lazy_attribute_works():
+    """Telemetry exports should load their source modules only when accessed."""
+    result = _run_isolated(
+        """
+import json
+import sys
+
+import esper.simic.telemetry
+from esper.simic.telemetry import RatioExplosionDiagnostic, TelemetryConfig
+
+print(json.dumps({
+    "RatioExplosionDiagnostic_type": str(type(RatioExplosionDiagnostic)),
+    "TelemetryConfig_type": str(type(TelemetryConfig)),
+    "diagnostic_cached": "RatioExplosionDiagnostic" in vars(esper.simic.telemetry),
+    "config_cached": "TelemetryConfig" in vars(esper.simic.telemetry),
+    "debug_loaded": "esper.simic.telemetry.debug_telemetry" in sys.modules,
+    "telemetry_config_loaded": "esper.simic.telemetry.telemetry_config" in sys.modules,
+}))
+""".strip()
+    )
+
+    assert "type" in result["RatioExplosionDiagnostic_type"]
+    assert "type" in result["TelemetryConfig_type"]
+    assert result["diagnostic_cached"] is True
+    assert result["config_cached"] is True
+    assert result["debug_loaded"] is True
+    assert result["telemetry_config_loaded"] is True
+
+
 def test_kasmina_import_isolation():
     """Importing esper.kasmina should NOT load torch or heavy modules."""
     result = _run_isolated(


### PR DESCRIPTION
## Summary
- lazy-load `ParallelEnvState` from `esper.simic.training` instead of importing heavy runtime state at package import
- resolve `esper.simic.safe` and `TaskConfig` directly from `esper.leyline` and cache the public exports
- replace eager `esper.simic.telemetry` package imports with a lazy export table
- add import-isolation regressions for the three tracked import-hygiene issues
- update recovery status after PR #86 and this local batch

## Verification
- `uv run pytest tests/test_import_isolation.py::test_simic_training_import_does_not_load_parallel_env_state tests/test_import_isolation.py::test_simic_training_parallel_env_state_lazy_attribute_works tests/test_import_isolation.py::test_simic_safe_task_config_resolve_from_leyline_without_tamiyo tests/test_import_isolation.py::test_simic_telemetry_import_isolation tests/test_import_isolation.py::test_simic_telemetry_lazy_attribute_works -q`
- `uv run pytest tests/test_import_isolation.py -q`
- `uv run pytest tests/simic/test_telemetry_config.py tests/simic/test_debug_telemetry.py tests/simic/test_gradient_collector.py tests/simic/test_anomaly_detector.py tests/simic/test_config.py tests/simic/training/test_config_validation.py -q`
- `uv run python scripts/lint_defensive_patterns.py`
- `uv run python scripts/lint_leyline_types.py`
- `uv run python scripts/lint_gpu_sync.py`
- `uv run ruff check src/ tests/`
- `MYPYPATH=src uv run mypy -p esper`
- `uv run pytest` (`4711 passed, 10 skipped, 69 deselected`)
- `wardline scan . --fail-on ERROR` (`0 active`)

Tracked issues: `esper-lite-0c7b3b`, `esper-lite-7481c4`, `esper-lite-eb5662`