### PR TITLE
test(tamiyo): lock op value action consistency

### DIFF
--- a/docs/bugs/investigations/CRITICAL-op-value-mismatch.md
+++ b/docs/bugs/investigations/CRITICAL-op-value-mismatch.md
@@ -1,16 +1,39 @@
 # CRITICAL BUG: Op Value/Action Mismatch in Q(s, op) Implementation
 
-**Status**: CRITICAL - Blocks Phase 7
+**Status**: RESOLVED - Fixed in `FactoredRecurrentActorCritic.get_action()` and covered by regression tests
 **Discovered**: 2025-12-31 (post-Phase 6 release review)
 **Severity**: Undermines Q(s, op) design, causes biased advantages
+**Resolved**: 2026-06-13 verification pass
 
 ---
 
 ## Executive Summary
 
-The Q(s, op) value head implementation in `FactoredRecurrentActorCritic.get_action()` computes the value using a **different op** than the op action stored in the buffer. This creates systematic bias in PPO advantage estimates.
+The historical Q(s, op) value head bug in `FactoredRecurrentActorCritic.get_action()` computed the value using a **different op** than the op action stored in the buffer. This created systematic bias in PPO advantage estimates.
 
-**Root Cause**: `forward()` samples the op for value computation, but `get_action()` independently samples (or argmaxes) the op for the action. These two ops frequently diverge.
+**Root Cause**: `forward()` sampled the op for value computation, but `get_action()` independently sampled (or argmaxed) the op for the action. These two ops frequently diverged.
+
+## Resolution
+
+Current `main` no longer has the mismatch described below.
+`FactoredRecurrentActorCritic.get_action()` now enforces one selected operation per action result:
+
+- stochastic rollout mode reuses `output["sampled_op"]` from `forward()` and returns the existing `Q(s, sampled_op)` value;
+- deterministic bootstrap mode selects the argmax operation and recomputes `Q(s, argmax_op)`;
+- `sampled_op`, `actions["op"]`, `log_probs["op"]`, and `values` are returned from the same selected operation contract.
+
+Regression coverage:
+
+- `tests/tamiyo/networks/test_op_value_consistency.py`
+- `tests/simic/training/test_bootstrap_consistency.py`
+
+Verification command:
+
+```bash
+uv run --python 3.11 pytest tests/tamiyo/networks/test_op_value_consistency.py tests/simic/training/test_bootstrap_consistency.py -q
+```
+
+The sections below are retained as historical diagnosis of the failure mode.
 
 ---
 

--- a/docs/coord/PLAN_TRACKER.md
+++ b/docs/coord/PLAN_TRACKER.md
@@ -1,6 +1,6 @@
 # Esper Plan Tracker
 
-**Last Updated:** 2026-06-13 (baseline green; recovery bug drain closed; Karn telemetry quality arc drafted)
+**Last Updated:** 2026-06-13 (baseline green; recovery bug drain closed; op/value mismatch verified resolved; Karn telemetry quality arc drafted)
 **Purpose:** Rack-and-stack all plans and concepts for prioritization and dependency tracking.
 
 ---
@@ -34,19 +34,23 @@ planning shell ready.
 Full codebase audit performed after returning from a month off. Many plans marked "0%" were
 actually completed during the Jan 9-17 implementation sprint but the tracker was never updated.
 
-### 🔴 CRITICAL: Op/Value Mismatch Bug
+### ✅ Resolved: Op/Value Mismatch Bug
 
 **CRITICAL-op-value-mismatch** (in `docs/bugs/investigations/`): Q(s,op) value head samples
 op twice independently — once in `forward()` for value computation, once in `get_action()` for
-the stored action. These ops frequently diverge, corrupting advantage estimates. Blocks Phase 7.
+the stored action. These ops frequently diverge, corrupting advantage estimates. This formerly
+blocked Phase 7.
+
+Resolution verified 2026-06-13: `get_action()` now reuses the sampled op in stochastic rollout mode,
+recomputes Q(s,argmax op) in deterministic bootstrap mode, and focused regression tests cover both paths.
 
 ### Current Focus Areas
 1. **Green State Recovery** - ✅ Completed; baseline green and recovery bug drain closed
-2. **Dependency/Branch Drain** - In progress; consolidate patch dependency PRs and return checkout to `main`
+2. **Dependency/Branch Drain** - ✅ Completed; patch dependency PRs consolidated, stale branches drained, checkout returned to `main`
 3. **Karn Telemetry Quality Arc** - Drafted; next upgrade package focused on Sanctum, Overwatch, MCP analytics, and telemetry contracts
 4. **P1 Stability Batch 1** - ✅ Completed and merged; six high-risk PPO/telemetry correctness bugs closed
 5. **P0 Filigree Bug Drain** - ✅ Initial six P0s fixed and closed
-6. **Op/Value Mismatch** - 🔴 CRITICAL! Fix double-sampling in factored_lstm.py
+6. **Op/Value Mismatch** - ✅ Resolved; focused regression tests cover rollout and bootstrap consistency
 7. **Reward Efficiency Experiment** - Infrastructure complete, experiment never run
 8. **Phase3-TinyStories** - 85% IMPLEMENTED, needs validation runs
 9. **Drip Reward Implementation** - ~70% done, needs integration completion
@@ -55,16 +59,16 @@ the stored action. These ops frequently diverge, corrupting advantage estimates.
 
 ### Critical Path (Updated)
 ```
-[op-value-mismatch 🔴] ──► reward-efficiency ──► counterfactual-oracle ──► emrakul-phase1
-                                    │
-                                    └──► blueprint-compiler ──► kasmina2-phase0
+reward-efficiency ──► counterfactual-oracle ──► emrakul-phase1
+              │
+              └──► blueprint-compiler ──► kasmina2-phase0
 ```
 
 ### Health Summary
 | Status | Count | Notes |
 |--------|-------|-------|
-| 🔴 Critical | 1 | op-value-mismatch (corrupts advantage estimates) |
-| Completed | 14 | simic2 (3) + entropy fixes (2) + holding-warning + simic-audit + dual-state lifecycle (2) + drip-reward design + 4 telemetry |
+| 🔴 Critical | 0 | No active Tier 0 correctness blockers after op/value verification |
+| Completed | 15 | simic2 (3) + entropy fixes (2) + holding-warning + simic-audit + dual-state lifecycle (2) + drip-reward design + 4 telemetry + op/value mismatch |
 | Ready | 11 | Implementation-ready plans |
 | In Progress | 1 | phase3-tinystories (85%) |
 | Planning | 6 | Active design workspaces |
@@ -83,7 +87,7 @@ the stored action. These ops frequently diverge, corrupting advantage estimates.
 | green-state-recovery-2026-06-12 | Green State Recovery Program | completed-batch | 🔴 critical | M | high | Completed: PRs #52, #72, #78-#88 merged; recovery bugs closed |
 | p1-stability-batch-1 | PPO/Telemetry Stability Batch 1 | completed-batch | 🔴 critical | M | high | Completed and merged; six bugs closed, broad gates passed |
 | filigree-p0-drain | Critical Filigree P0 Bug Drain | completed-batch | 🔴 critical | L | high | Initial six P0s fixed, verified, and closed |
-| op-value-mismatch | Q(s,op) Double-Sampling Bug | investigation | 🔴 critical | M | high | Diagnosed 2025-12-31, blocks Phase 7. See `docs/bugs/investigations/` |
+| op-value-mismatch | Q(s,op) Double-Sampling Bug | investigation | 🔴 critical | M | high | Completed: stochastic rollout uses one sampled op; deterministic bootstrap recomputes Q(s,argmax op); regression tests pass |
 
 ### Tier 1: High Priority (This Week)
 
@@ -1147,7 +1151,7 @@ percent_complete: 0
 
 | Plan | Risk Level | Primary Risk | Mitigation |
 |------|------------|--------------|------------|
-| op-value-mismatch | 🔴 CRITICAL | Corrupts advantage estimates in all training | Fix double-sampling in factored_lstm.py |
+| op-value-mismatch | RESOLVED | Formerly corrupted advantage estimates in all training | Fixed in factored_lstm.py; regression tests cover stochastic and deterministic paths |
 | counterfactual-oracle | HIGH | Goodhart/reward hacking | Probe as observation only, never as reward |
 | emrakul-immune | HIGH | Novel architecture, two-timescale learning | Phased rollout, Shapley labels in Phase 1 only |
 | phase3-tinystories | HIGH | NaN spikes on graft | Zero-init projections, LayerNorm pre-injection |
@@ -1166,16 +1170,19 @@ percent_complete: 0
 
 ### Immediate Actions (This Week)
 
-1. **Fix op-value-mismatch** - CRITICAL bug corrupting advantage estimates. See `docs/bugs/investigations/CRITICAL-op-value-mismatch.md`
-
-2. **Run reward-efficiency experiment** - Infrastructure is 100% complete:
+1. **Run reward-efficiency experiment** - Infrastructure is 100% complete and the op/value blocker is resolved:
    ```bash
    uv run python -m esper.scripts.train ppo --dual-ab shaped-vs-simplified --episodes 100
    ```
 
-3. **Run TinyStories baseline** - Implementation is 85% complete:
+2. **Run TinyStories baseline** - Implementation is 85% complete:
    ```bash
    uv run python -m esper.scripts.train ppo --task tinystories --episodes 50
+   ```
+
+3. **Start Karn Telemetry Quality Sprint 1** - Repair the evidence surface before deeper refactors:
+   ```bash
+   uv run --python 3.11 pytest tests/karn -q
    ```
 
 ### Short-Term (Next 2 Weeks)
@@ -1209,6 +1216,7 @@ percent_complete: 0
 
 | Date | Change |
 |------|--------|
+| 2026-06-13 | **OP/VALUE MISMATCH VERIFIED RESOLVED.** `get_action()` uses one selected op for action, log-prob, and Q(s,op) value in stochastic rollout mode, and recomputes Q(s,argmax op) for deterministic bootstrap. Added direct regression probes and updated active critical count to 0. |
 | 2026-02-21 | **POST-HIATUS FULL AUDIT.** Returned after 1-month break. Comprehensive codebase audit using explore agents: |
 | | **Plans moved to completed/ (5 files):** |
 | | - op-entropy-collapse: FULLY IMPLEMENTED Jan 9-11 (probability floors + entropy floors) |
@@ -1219,8 +1227,8 @@ percent_complete: 0
 | | - emrakul-submodule-editing: Moved from concepts/ (self-documents supersession) |
 | | **Plans moved to ready/ (1 file):** |
 | | - phase3-tinystories-strategy: Moved from concepts/ (85% implemented, needs validation runs) |
-| | **Critical bug surfaced:** |
-| | - CRITICAL-op-value-mismatch in investigations/: Q(s,op) double-sampling corrupts advantages |
+| | **Critical bug surfaced, later resolved 2026-06-13:** |
+| | - CRITICAL-op-value-mismatch in investigations/: Q(s,op) double-sampling corrupted advantages |
 | | **Bugs folder audited:** 307+ files across fixed/triaged/wontfix/not-a-bug/generated. |
 | | - 14 generated Codex analysis files need triage |
 | | - 0 skip/xfail markers in tests (good hygiene) |
@@ -1352,7 +1360,7 @@ Quick reference for all tracked plans:
 ### bugs/ (Issue Tracking)
 | Category | Count | Notes |
 |----------|-------|-------|
-| `investigations/` | 4 | Includes CRITICAL-op-value-mismatch |
+| `investigations/` | 4 | Includes resolved CRITICAL-op-value-mismatch historical diagnosis |
 | `fixed/` | 90 | Resolved with code changes |
 | `triaged/` | 108 | Analyzed, awaiting implementation |
 | `wontfix/` | 49 | Intentionally deferred |

--- a/src/esper/karn/sanctum/app.py
+++ b/src/esper/karn/sanctum/app.py
@@ -807,12 +807,15 @@ class SanctumApp(App[None]):
         self._active_group_id = next_group_id
         self.notify(f"Policy group: {next_group_id}", severity="information")
 
-        self.view = SanctumView(
+        next_view = SanctumView(
             primary_group_id=next_group_id,
             primary=view.snapshots_by_group[next_group_id],
             snapshots_by_group=view.snapshots_by_group,
             reward_health_by_group=view.reward_health_by_group,
         )
+        self.view = next_view
+        self._snapshot = next_view.primary
+        self._apply_view(next_view)
 
     def action_show_run_info(self) -> None:
         """Show full run information modal (untruncated task name, etc.)."""

--- a/tests/tamiyo/networks/test_op_value_consistency.py
+++ b/tests/tamiyo/networks/test_op_value_consistency.py
@@ -4,10 +4,11 @@ CRITICAL BUG FIX: Verify that get_action() uses the same op for both
 value computation and action selection. This prevents biased advantages
 and bootstrap corruption.
 
-Related bug report: docs/bugs/CRITICAL-op-value-mismatch.md
+Related bug report: docs/bugs/investigations/CRITICAL-op-value-mismatch.md
 """
 
 import torch
+from torch import nn
 import pytest
 from esper.tamiyo.networks import FactoredRecurrentActorCritic
 from esper.leyline import HEAD_NAMES
@@ -27,6 +28,53 @@ class TestOpValueConsistency:
         bp_idx = torch.randint(0, 13, (batch_size, 3))
         masks = {k: None for k in HEAD_NAMES}
         return state, bp_idx, masks
+
+    def test_stochastic_value_is_conditioned_on_returned_op(self, monkeypatch, network, inputs):
+        """Stochastic rollouts must not use a second independent op sample for value."""
+        state, bp_idx, _ = inputs
+
+        class UniformOpHead(nn.Module):
+            def forward(self, lstm_out: torch.Tensor) -> torch.Tensor:
+                return lstm_out.new_zeros((*lstm_out.shape[:-1], network.num_ops))
+
+        def value_equals_op(lstm_out: torch.Tensor, op: torch.Tensor) -> torch.Tensor:
+            return op.to(lstm_out)
+
+        network.op_head = UniformOpHead()
+        monkeypatch.setattr(network, "_compute_value", value_equals_op)
+
+        torch.manual_seed(0)
+        result = network.get_action(state, bp_idx, hidden=None, deterministic=False)
+
+        torch.testing.assert_close(
+            result.values,
+            result.actions["op"].to(result.values),
+            msg="rollout value must be Q(s, returned op), not Q(s, an earlier op sample)",
+        )
+
+    def test_deterministic_value_is_conditioned_on_argmax_op(self, monkeypatch, network, inputs):
+        """Bootstrap values must be recomputed for the deterministic argmax op."""
+        state, bp_idx, _ = inputs
+
+        class UniformOpHead(nn.Module):
+            def forward(self, lstm_out: torch.Tensor) -> torch.Tensor:
+                return lstm_out.new_zeros((*lstm_out.shape[:-1], network.num_ops))
+
+        def value_equals_op(lstm_out: torch.Tensor, op: torch.Tensor) -> torch.Tensor:
+            return op.to(lstm_out)
+
+        network.op_head = UniformOpHead()
+        monkeypatch.setattr(network, "_compute_value", value_equals_op)
+
+        torch.manual_seed(0)
+        result = network.get_action(state, bp_idx, hidden=None, deterministic=True)
+
+        assert (result.actions["op"] == 0).all()
+        torch.testing.assert_close(
+            result.values,
+            torch.zeros_like(result.values),
+            msg="deterministic value must be Q(s, argmax op), not Q(s, forward sample)",
+        )
 
     def test_deterministic_op_value_match(self, network, inputs):
         """In deterministic mode, value must use argmax op."""


### PR DESCRIPTION
## Summary
- add direct regression probes proving stochastic rollout values are conditioned on the returned sampled op
- add deterministic bootstrap coverage proving values are recomputed for argmax op
- mark the historical op/value mismatch investigation and plan tracker as resolved so the critical path moves to reward-efficiency
- apply Karn policy-group toggles immediately to remove the CI-observed async refresh race in the PR test job

## Notes
The production get_action/evaluate_actions invariant is already present on current main: stochastic rollout reuses sampled_op, deterministic bootstrap recomputes Q(s,argmax op), and evaluate_actions conditions on stored actions["op"]. This PR locks that behavior with focused tests and updates stale coordination docs.

## Verification
- uv run ruff check tests/tamiyo/networks/test_op_value_consistency.py
- uv run ruff check src/ tests/
- uv run ruff check src/esper/karn/sanctum/app.py tests/tamiyo/networks/test_op_value_consistency.py
- git diff --check
- uv run --python 3.11 pytest tests/tamiyo/networks/test_op_value_consistency.py tests/simic/training/test_bootstrap_consistency.py -q
- uv run --python 3.11 pytest -m "not integration and not stress and not property" -x
- uv run --python 3.11 pytest -m integration tests/integration/test_q_values_telemetry.py -q
- uv run --python 3.11 pytest tests/karn/sanctum/test_app_integration.py -q

Reduced suite result before the Karn CI repair commit: 4474 passed, 6 skipped, 313 deselected. Karn app integration after the repair: 12 passed.