### PR TITLE
feat(ci): Weft Phase A shadow-CI + parity reporting

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -37,6 +37,83 @@ jobs:
         with:
           args: "check src/ tests/"
 
+  weft-shadow:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Install project dependencies
+        run: uv sync --group dev
+
+      - name: Install Weft CLI tools
+        run: |
+          uv tool install wardline==1.0.1
+          uv tool install loomweave==1.1.0
+          uv tool install loomweave-plugin-python==1.1.0rc5
+          uv tool install legis==1.0.0
+          uv tool install warpline==1.0.0
+
+      - name: Prepare Weft artifact directory
+        run: mkdir -p "$RUNNER_TEMP/weft-shadow"
+
+      - name: Run Wardline shadow scan
+        continue-on-error: true
+        run: |
+          wardline doctor --root . > "$RUNNER_TEMP/weft-shadow/wardline-doctor.txt"
+          wardline scan . \
+            --config weft.toml \
+            --local-only \
+            --format jsonl \
+            --fail-on error \
+            --fail-on-unanalyzed \
+            --output "$RUNNER_TEMP/weft-shadow/wardline.jsonl"
+
+      - name: Refresh Loomweave index
+        continue-on-error: true
+        run: |
+          loomweave install --path . \
+            > "$RUNNER_TEMP/weft-shadow/loomweave-install.txt"
+          loomweave analyze . --config loomweave.yaml --no-incremental --json \
+            > "$RUNNER_TEMP/weft-shadow/loomweave-analyze.txt"
+          loomweave doctor --path . --format json \
+            > "$RUNNER_TEMP/weft-shadow/loomweave-doctor.json"
+
+      - name: Capture Legis and Warpline readiness
+        continue-on-error: true
+        run: |
+          legis doctor --format json > "$RUNNER_TEMP/weft-shadow/legis-doctor.json"
+          warpline install --repo . --config --json \
+            > "$RUNNER_TEMP/weft-shadow/warpline-install.json"
+          warpline doctor --repo . --json > "$RUNNER_TEMP/weft-shadow/warpline-doctor.json"
+
+      - name: Build Weft parity report
+        run: |
+          uv run python scripts/ci_weft_parity.py \
+            --output "$RUNNER_TEMP/weft-shadow/parity.json" \
+            --artifacts-dir "$RUNNER_TEMP/weft-shadow" \
+            --wardline-output "$RUNNER_TEMP/weft-shadow/wardline.jsonl"
+
+      - name: Upload Weft shadow artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: weft-shadow-${{ github.sha }}
+          path: ${{ runner.temp }}/weft-shadow/**
+
   typecheck:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/docs/coord/PLAN_TRACKER.md
+++ b/docs/coord/PLAN_TRACKER.md
@@ -76,11 +76,11 @@ correctness-proof-strategy ──► morphogenesis-governor-integrity ──► 
 | 🔴 Critical | 0 | New governor-integrity issues are high-priority proof blockers, not active Tier 0 mainline breakage |
 | Completed | 16 | simic2 (3) + entropy fixes (2) + holding-warning + simic-audit + dual-state lifecycle (2) + drip-reward design + 4 telemetry + op/value mismatch + training-perf-master (2026-06-14) |
 | Ready | 14 | Implementation-ready plans (incl. post-P0-1 sprint umbrella + EV-telemetry-robustness + 0.1.1→main-merge, authored 2026-06-18) |
-| In Progress | 1 | phase3-tinystories (85%) |
+| In Progress | 2 | phase3-tinystories (85%); weft-phase-a-ci-migration (Phase A shadow-CI) |
 | Planning | 11 | Active design workspaces, including correctness proof strategy, governor-integrity, PPO oracle sandbox, and proof baseline controls |
 | Concept | 4 | counterfactual-oracle, emrakul-sketch, scaled-counterfactuals, gil-throughput-profiler |
 | Abandoned | 3 | shaped-delta-clip, emrakul-submodule-editing, scry-design |
-| **Total Active** | **34** |
+| **Total Active** | **35** |
 
 ---
 
@@ -114,6 +114,7 @@ correctness-proof-strategy ──► morphogenesis-governor-integrity ──► 
 | post-p01-hardening-sprint | Post-P0-1 Hardening & Integration Sprint | sprint-umbrella | high | M | medium | Authored 2026-06-18 (`docs/plans/ready/2026-06-18-post-p01-hardening-sprint.md`); umbrella for items 1-3 (EV-telemetry robustness, 0.1.1→main merge, dependency-vuln triage); 10-SME panel + synthesizer reviewed (verdict CHANGES_REQUESTED → must_do applied; child blockers fixed & codebase-verified) |
 | ev-telemetry-robustness | EV-Telemetry Robustness (low-return-variance artifact) | ready | high | M | medium | Authored 2026-06-18 (spec+plan); make `explained_variance` honest under P0-1's op-marginal V(s) (variance floor + `value_nrmse`/`ev_return_variance`, NOT bug-hiding) + audit EV consumers/gates; Step 0 empirical floor calibration is a HARD precondition |
 | main-merge-integration | 0.1.1 → main Merge & Integration | ready | high | L | high | Authored 2026-06-18 (spec+plan); ~42-commit FF merge carrying the VALUE_HEAD_SCHEMA_VERSION=2 checkpoint break; EV gate-fix (item 1) is a hard structural co-land precondition; dependency-vuln bump pass rides the window |
+| weft-phase-a-ci-migration | Weft Phase A CI Migration | in-progress | high | M | medium | Phase A landed on `weft-phase-a` (PR into 0.1.1): non-blocking `weft-shadow` CI job + `weft_parity.py`/`ci_weft_parity.py` parity report. Homegrown gates stay blocking; no gate retires until zero homegrown-only burn-in evidence exists |
 
 ### Tier 2: Medium Priority (Next 2 Weeks)
 

--- a/docs/plans/ready/2026-06-18-weft-phase-a-ci-migration.md
+++ b/docs/plans/ready/2026-06-18-weft-phase-a-ci-migration.md
@@ -1,0 +1,74 @@
+# Weft Phase A CI Migration
+
+## Plan Metadata
+
+```yaml
+id: weft-phase-a-ci-migration
+title: Weft Phase A CI Migration
+type: in-progress
+created: 2026-06-18
+updated: 2026-06-18
+owner: John
+urgency: high
+value: Adds Wardline, Loomweave, Legis, and Warpline evidence to CI without removing existing gates before parity is proven.
+complexity: M
+risk: medium
+risk_notes: The Weft tools do not yet prove replacement parity for every homegrown check; retirement must be evidence-gated.
+depends_on: []
+soft_depends:
+  - docs/superpowers/specs/2026-06-15-weft-ci-migration-design.md
+blocks: []
+status_notes: Phase A shadow CI scaffold is implemented on codex/weft-phase-a-ci-migration. No homegrown check is retired in the setup PR.
+percent_complete: 55
+reviewed_by:
+  - reviewer: python-engineering
+    date: 2026-06-18
+    verdict: approved-with-changes
+    notes: Keep shadow CI non-blocking and preserve custom gates until zero homegrown-only parity evidence exists.
+```
+
+## Scope
+
+Phase A adds a non-blocking `weft-shadow` job and a local parity report. It does
+not replace `ruff`, `mypy`, pytest tiers, coverage, web tests, proof-packet
+checks, or the GPU-sync linter.
+
+The shadow job is a narrow owner-approved exception to the no-dual-implementation
+policy in `CLAUDE.md`. It is CI verification only, introduces no runtime dual
+path, and expires per check after 20 PRs or 14 days with zero homegrown-only
+findings.
+
+## Implementation
+
+- Keep existing blocking lint steps unchanged: Leyline type boundaries,
+  defensive-pattern whitelist, GPU-sync whitelist, and Ruff.
+- Add `weft-shadow` to `.github/workflows/test-suite.yml` with
+  `continue-on-error: true` and artifact upload from `$RUNNER_TEMP/weft-shadow`.
+- Pin the first shadow toolchain to Wardline 1.0.1, Loomweave 1.1.0,
+  Loomweave Python plugin 1.1.0rc5, Legis 1.0.0, and Warpline 1.0.0.
+- Write report artifacts only to `$RUNNER_TEMP`; ignored `.weft/` stores may be
+  initialized in the ephemeral CI checkout for tools that require local state.
+  Do not emit `findings.jsonl` into the repo tree.
+- Build the parity report with `scripts/ci_weft_parity.py`.
+
+## Replacement Readiness
+
+- `lint_defensive_patterns.py`: stays blocking until Wardline emits a mapped
+  defensive-pattern rule family and parity shows zero homegrown-only findings.
+- `lint_leyline_types.py`: stays blocking until Loomweave exposes class contract
+  kind metadata for enum, dataclass, protocol, TypedDict, and NamedTuple
+  placement, including stale-whitelist semantics.
+- `scripts/test_import_cycle.py`: is not a current CI gate and checks lazy import
+  side effects, so it is not counted as retired by a Loomweave module-cycle
+  artifact.
+- `lint_gpu_sync.py`: remains homegrown. The current Weft toolchain has no
+  equivalent CUDA-sync policy.
+
+## Acceptance
+
+- Existing blocking CI behavior remains intact.
+- `weft-shadow` publishes Wardline, Loomweave, Legis, Warpline, and parity
+  artifacts on every pull request.
+- The parity report marks replacement readiness false throughout Phase A; it
+  exposes `shadow_signal_ready` separately from the later retirement decision.
+- Retirement happens only in a later per-check PR after the burn-in window.

--- a/scripts/ci_weft_parity.py
+++ b/scripts/ci_weft_parity.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+from esper.utils.weft_parity import (
+    build_phase_a_report,
+    inspect_loomweave_db,
+    parse_defensive_output,
+    parse_leyline_output,
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Build the Phase A Weft parity report."
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--artifacts-dir", type=Path, required=True)
+    parser.add_argument(
+        "--wardline-output",
+        type=Path,
+        help="Wardline JSONL output. Defaults to ARTIFACTS_DIR/wardline.jsonl.",
+    )
+    parser.add_argument(
+        "--loomweave-db",
+        type=Path,
+        default=Path(".weft/loomweave/loomweave.db"),
+    )
+    parser.add_argument("--history-count", type=int, default=0)
+    parser.add_argument(
+        "--fail-on-homegrown-only",
+        action="store_true",
+        help="Exit 1 when the parity report contains homegrown-only findings.",
+    )
+    args = parser.parse_args()
+
+    artifacts_dir: Path = args.artifacts_dir
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    defensive_result = _run([sys.executable, "scripts/lint_defensive_patterns.py"])
+    leyline_result = _run([sys.executable, "scripts/lint_leyline_types.py"])
+    _write_command_output(
+        artifacts_dir / "homegrown-defensive-patterns.txt", defensive_result
+    )
+    _write_command_output(artifacts_dir / "homegrown-leyline-types.txt", leyline_result)
+
+    wardline_output = _wardline_output_path(args.wardline_output, artifacts_dir)
+    if not wardline_output.exists():
+        wardline_output.write_text("")
+
+    report = build_phase_a_report(
+        wardline_output=wardline_output,
+        loomweave=inspect_loomweave_db(args.loomweave_db),
+        defensive_findings=parse_defensive_output(
+            defensive_result.stdout + defensive_result.stderr
+        ),
+        leyline_findings=parse_leyline_output(leyline_result.stdout + leyline_result.stderr),
+    )
+    report["metadata"] = {
+        "schema": "esper-weft-parity-metadata-v1",
+        "history_count_requested": args.history_count,
+        "history_evaluated": False,
+        "homegrown_exit_codes": {
+            "defensive-patterns": defensive_result.returncode,
+            "leyline-types": leyline_result.returncode,
+        },
+    }
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+
+    if args.fail_on_homegrown_only and _has_homegrown_only(report):
+        return 1
+    return 0
+
+
+def _run(command: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_command_output(
+    path: Path, result: subprocess.CompletedProcess[str]
+) -> None:
+    path.write_text(result.stdout + result.stderr)
+
+
+def _wardline_output_path(raw_path: Path | None, artifacts_dir: Path) -> Path:
+    if raw_path is None:
+        return artifacts_dir / "wardline.jsonl"
+    return raw_path
+
+
+def _has_homegrown_only(report: dict[str, Any]) -> bool:
+    for check in report["checks"]:
+        if len(check["homegrown_only"]) > 0:
+            return True
+    return False
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/esper/simic/training/action_execution.py
+++ b/src/esper/simic/training/action_execution.py
@@ -65,8 +65,6 @@ from .handlers import (
 )
 from .parallel_env_state import ParallelEnvState
 from esper.simic.vectorized_types import (
-    ActionMaskFlags,
-    ActionOutcome,
     ActionSpec,
     EnvStepRecord,
     EpisodeRecord,

--- a/src/esper/utils/weft_parity.py
+++ b/src/esper/utils/weft_parity.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+
+class NormalizedFinding:
+    def __init__(
+        self,
+        *,
+        check: str,
+        file: str,
+        line: int | None,
+        rule: str,
+        key: str,
+        source: str,
+        message: str,
+    ) -> None:
+        self.check = check
+        self.file = file
+        self.line = line
+        self.rule = rule
+        self.key = key
+        self.source = source
+        self.message = message
+
+
+class LoomweaveCapabilities:
+    def __init__(
+        self,
+        *,
+        db_path: Path,
+        database_present: bool,
+        class_contract_kind_present: bool,
+        module_import_edges_present: bool,
+        module_cycles: list[list[str]],
+    ) -> None:
+        self.db_path = db_path
+        self.database_present = database_present
+        self.class_contract_kind_present = class_contract_kind_present
+        self.module_import_edges_present = module_import_edges_present
+        self.module_cycles = module_cycles
+
+
+def inspect_loomweave_db(db_path: Path) -> LoomweaveCapabilities:
+    if not db_path.exists():
+        return LoomweaveCapabilities(
+            db_path=db_path,
+            database_present=False,
+            class_contract_kind_present=False,
+            module_import_edges_present=False,
+            module_cycles=[],
+        )
+
+    connection = sqlite3.connect(db_path)
+    class_kind_count = connection.execute(
+        """
+        select count(*)
+        from entities
+        where kind = 'class'
+          and json_extract(properties, '$.python.class_contract_kind') is not null
+        """
+    ).fetchone()[0]
+    import_edge_count = connection.execute(
+        """
+        select count(*)
+        from edges
+        where kind = 'imports'
+        """
+    ).fetchone()[0]
+    import_edges = connection.execute(
+        """
+        select source.name, target.name
+        from edges
+        join entities source on source.id = edges.from_id
+        join entities target on target.id = edges.to_id
+        where edges.kind = 'imports'
+          and source.kind = 'module'
+          and target.kind = 'module'
+        """
+    ).fetchall()
+    connection.close()
+
+    return LoomweaveCapabilities(
+        db_path=db_path,
+        database_present=True,
+        class_contract_kind_present=class_kind_count > 0,
+        module_import_edges_present=import_edge_count > 0,
+        module_cycles=_module_cycles(import_edges),
+    )
+
+
+def _module_cycles(import_edges: list[tuple[str, str]]) -> list[list[str]]:
+    graph: dict[str, list[str]] = {}
+    for source, target in import_edges:
+        if source not in graph:
+            graph[source] = []
+        if target not in graph:
+            graph[target] = []
+        graph[source].append(target)
+
+    index_by_node: dict[str, int] = {}
+    lowlink_by_node: dict[str, int] = {}
+    stack: list[str] = []
+    nodes_on_stack: set[str] = set()
+    components: list[list[str]] = []
+    next_index = 0
+
+    def visit(node: str) -> None:
+        nonlocal next_index
+        index_by_node[node] = next_index
+        lowlink_by_node[node] = next_index
+        next_index += 1
+        stack.append(node)
+        nodes_on_stack.add(node)
+
+        for target in graph[node]:
+            if target not in index_by_node:
+                visit(target)
+                lowlink_by_node[node] = min(lowlink_by_node[node], lowlink_by_node[target])
+            elif target in nodes_on_stack:
+                lowlink_by_node[node] = min(lowlink_by_node[node], index_by_node[target])
+
+        if lowlink_by_node[node] != index_by_node[node]:
+            return
+
+        component: list[str] = []
+        while True:
+            member = stack.pop()
+            nodes_on_stack.remove(member)
+            component.append(member)
+            if member == node:
+                break
+        if len(component) > 1:
+            components.append(sorted(component))
+
+    for node in sorted(graph):
+        if node not in index_by_node:
+            visit(node)
+
+    return sorted(components)
+
+
+def parse_leyline_output(output: str) -> list[NormalizedFinding]:
+    findings: list[NormalizedFinding] = []
+    for raw_line in output.splitlines():
+        line = raw_line.strip()
+        if line.startswith("ERROR: "):
+            findings.append(_parse_leyline_violation(line))
+            continue
+        if not _looks_like_leyline_stale_key(line):
+            continue
+        parts = line.split(":")
+        path = parts[0]
+        kind = parts[1]
+        name = parts[2]
+        findings.append(
+            NormalizedFinding(
+                check="leyline-types",
+                file=path,
+                line=None,
+                rule="stale-whitelist",
+                key=line,
+                source="homegrown",
+                message=f"{kind} {name} is no longer emitted by lint_leyline_types.py",
+            )
+        )
+    return findings
+
+
+def parse_defensive_output(output: str) -> list[NormalizedFinding]:
+    findings: list[NormalizedFinding] = []
+    lines = output.splitlines()
+    for index, raw_line in enumerate(lines):
+        line = raw_line.strip()
+        if not line.startswith("src/"):
+            continue
+        if _looks_like_defensive_stale_key(line):
+            findings.append(_parse_defensive_stale_key(line))
+            continue
+        if ": " not in line or " in " not in line:
+            continue
+        parts = line.split(":")
+        path = parts[0]
+        line_number = int(parts[1])
+        detail = ":".join(parts[2:]).strip()
+        rule = detail.split(" in ")[0]
+        key = _following_key(lines, index)
+        if key == "":
+            continue
+        findings.append(
+            NormalizedFinding(
+                check="defensive-patterns",
+                file=path,
+                line=line_number,
+                rule=rule,
+                key=key,
+                source="homegrown",
+                message=detail,
+            )
+        )
+    return findings
+
+
+def _following_key(lines: list[str], index: int) -> str:
+    for raw_line in lines[index + 1 : index + 4]:
+        line = raw_line.strip()
+        if line.startswith("Key:"):
+            return line.removeprefix("Key:").strip()
+    return ""
+
+
+def build_phase_a_report(
+    *,
+    wardline_output: Path,
+    loomweave: LoomweaveCapabilities,
+    defensive_findings: list[NormalizedFinding],
+    leyline_findings: list[NormalizedFinding],
+) -> dict[str, Any]:
+    wardline_missing = not wardline_output.exists()
+    wardline_has_defensive_rule = (
+        False if wardline_missing else _wardline_has_defensive_rule(wardline_output)
+    )
+    defensive_blockers: list[str] = []
+    if wardline_missing:
+        defensive_blockers.append(
+            "Wardline artifact is missing; inspect the Wardline shadow step before evaluating defensive-pattern parity."
+        )
+    elif not wardline_has_defensive_rule:
+        defensive_blockers.append(
+            "Wardline emitted no defensive-pattern rule mapping; keep lint_defensive_patterns.py blocking."
+        )
+
+    leyline_blockers: list[str] = []
+    if not loomweave.class_contract_kind_present:
+        leyline_blockers.append(
+            "Loomweave class_contract_kind metadata is not present; keep lint_leyline_types.py blocking."
+        )
+
+    module_cycle_blockers: list[str] = []
+    if not loomweave.database_present:
+        module_cycle_blockers.append(
+            "Loomweave database is missing; run loomweave analyze before evaluating module cycles."
+        )
+    if not loomweave.module_import_edges_present:
+        module_cycle_blockers.append(
+            "Loomweave module import edges are missing; module-cycle replacement is not evaluable."
+        )
+    if len(loomweave.module_cycles) > 0:
+        module_cycle_blockers.append(
+            "Loomweave reported module cycles; keep module-cycle evidence advisory until triaged."
+        )
+
+    return {
+        "schema": "esper-weft-parity-v1",
+        "checks": [
+            _phase_a_check(
+                check="defensive-patterns",
+                shadow_signal_ready=len(defensive_blockers) == 0
+                and len(defensive_findings) == 0,
+                matches=[],
+                weft_only=[],
+                homegrown_only=_finding_dicts(defensive_findings),
+                blockers=defensive_blockers,
+            ),
+            _phase_a_check(
+                check="leyline-types",
+                shadow_signal_ready=len(leyline_blockers) == 0
+                and len(leyline_findings) == 0,
+                matches=[],
+                weft_only=[],
+                homegrown_only=_finding_dicts(leyline_findings),
+                blockers=leyline_blockers,
+            ),
+            _phase_a_check(
+                check="module-cycles",
+                shadow_signal_ready=len(module_cycle_blockers) == 0,
+                matches=[],
+                weft_only=[
+                    {
+                        "check": "module-cycles",
+                        "rule": "loomweave-module-cycle",
+                        "cycle": cycle,
+                    }
+                    for cycle in loomweave.module_cycles
+                ],
+                homegrown_only=[],
+                blockers=module_cycle_blockers,
+            ),
+        ],
+    }
+
+
+def _phase_a_check(
+    *,
+    check: str,
+    shadow_signal_ready: bool,
+    matches: list[dict[str, Any]],
+    weft_only: list[dict[str, Any]],
+    homegrown_only: list[dict[str, Any]],
+    blockers: list[str],
+) -> dict[str, Any]:
+    phase_a_gate = (
+        "Phase A shadow burn-in is not complete; keep the homegrown gate blocking "
+        "until 20 PRs or 14 days have zero homegrown-only findings."
+    )
+    return {
+        "check": check,
+        "replacement_ready": False,
+        "shadow_signal_ready": shadow_signal_ready,
+        "matches": matches,
+        "weft_only": weft_only,
+        "homegrown_only": homegrown_only,
+        "blockers": blockers + [phase_a_gate],
+        "retirement_gate": {
+            "required": "20 PRs or 14 days with zero homegrown-only findings",
+            "satisfied": False,
+        },
+    }
+
+
+def _looks_like_leyline_stale_key(line: str) -> bool:
+    if not line.startswith("src/esper/"):
+        return False
+    return (
+        ":enum:" in line
+        or ":dataclass:" in line
+        or ":protocol:" in line
+        or ":typeddict:" in line
+        or ":namedtuple:" in line
+    )
+
+
+def _parse_leyline_violation(line: str) -> NormalizedFinding:
+    match = re.fullmatch(
+        r"ERROR: (?P<path>[^:]+):(?P<line>\d+): "
+        r"(?P<kind>enum|dataclass|protocol|typeddict|namedtuple) "
+        r"'(?P<name>[^']+)' not in leyline or whitelist",
+        line,
+    )
+    if match is None:
+        raise ValueError(f"Unrecognized leyline violation: {line}")
+    kind = match["kind"]
+    name = match["name"]
+    path = match["path"]
+    return NormalizedFinding(
+        check="leyline-types",
+        file=path,
+        line=int(match["line"]),
+        rule=kind,
+        key=f"{path}:{kind}:{name}",
+        source="homegrown",
+        message=f"{kind} {name} not in leyline or whitelist",
+    )
+
+
+def _looks_like_defensive_stale_key(line: str) -> bool:
+    parts = line.split(":")
+    if len(parts) not in (3, 4):
+        return False
+    return (
+        line.startswith("src/esper/")
+        and parts[2]
+        in {"getattr", "hasattr", "silent_except", "bare_except", "isinstance", "get"}
+    )
+
+
+def _parse_defensive_stale_key(line: str) -> NormalizedFinding:
+    parts = line.split(":")
+    path = parts[0]
+    pattern = parts[2]
+    return NormalizedFinding(
+        check="defensive-patterns",
+        file=path,
+        line=None,
+        rule="stale-whitelist",
+        key=line,
+        source="homegrown",
+        message=f"{pattern} whitelist entry is stale",
+    )
+
+
+def _finding_dicts(findings: list[NormalizedFinding]) -> list[dict[str, Any]]:
+    return [
+        {
+            "check": finding.check,
+            "file": finding.file,
+            "line": finding.line,
+            "rule": finding.rule,
+            "key": finding.key,
+            "source": finding.source,
+            "message": finding.message,
+        }
+        for finding in findings
+    ]
+
+
+def _wardline_has_defensive_rule(wardline_output: Path) -> bool:
+    for raw_line in wardline_output.read_text().splitlines():
+        if raw_line == "":
+            continue
+        payload = json.loads(raw_line)
+        rule_id = str(payload["rule_id"])
+        if "DEFENSIVE" in rule_id or "BUG-HIDING" in rule_id:
+            return True
+    return False

--- a/tests/simic/training/test_run_phase_characterization.py
+++ b/tests/simic/training/test_run_phase_characterization.py
@@ -7,10 +7,6 @@ Run with:
 """
 from __future__ import annotations
 
-import contextlib
-from types import SimpleNamespace
-from unittest.mock import MagicMock, call, patch
-
 import pytest
 import torch
 
@@ -70,7 +66,6 @@ def test_i6_rollout_autocast_reads_trainer_fields():
     reading these two trainer fields. This test verifies the factory returns
     the context manager from policy_amp_context with those args.
     """
-    from esper.simic.training.vectorized_trainer import VectorizedPPOTrainer
     from esper.simic.training.helpers import policy_amp_context  # NOTE: lives in helpers.py, not a policy_amp module
 
     # We cannot instantiate VectorizedPPOTrainer easily, but we can verify
@@ -96,8 +91,6 @@ def test_i11_profiler_exits_in_finally_on_exception():
     is in a finally block. We verify by patching training_profiler to a
     recording context manager and injecting an exception in the batch loop.
     """
-    from esper.simic.training import vectorized_trainer
-
     exit_calls = []
 
     class _RecordingCM:
@@ -108,9 +101,8 @@ def test_i11_profiler_exits_in_finally_on_exception():
             exit_calls.append(args)
             return False
 
-    # Use SimpleNamespace stub to verify the finally branch.
     cm = _RecordingCM()
-    prof = cm.__enter__()
+    cm.__enter__()
     try:
         raise RuntimeError("injected test exception")
     except RuntimeError:

--- a/tests/utils/test_weft_parity.py
+++ b/tests/utils/test_weft_parity.py
@@ -1,0 +1,243 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from esper.utils.weft_parity import (
+    LoomweaveCapabilities,
+    build_phase_a_report,
+    inspect_loomweave_db,
+    parse_defensive_output,
+    parse_leyline_output,
+)
+
+
+def test_parse_leyline_output_records_stale_whitelist_entries() -> None:
+    output = """
+Checked 163 files, 148 type definitions
+Stale whitelist entries: 2
+
+STALE WHITELIST ENTRIES FOUND:
+
+  src/esper/simic/rewards/reward_telemetry.py:dataclass:RewardComponentsTelemetry
+  src/esper/simic/telemetry/observation_stats.py:dataclass:ObservationStatsTelemetry
+
+To fix: remove or update these keys in leyline_boundaries.yaml
+"""
+
+    findings = parse_leyline_output(output)
+
+    assert [finding.key for finding in findings] == [
+        "src/esper/simic/rewards/reward_telemetry.py:dataclass:RewardComponentsTelemetry",
+        "src/esper/simic/telemetry/observation_stats.py:dataclass:ObservationStatsTelemetry",
+    ]
+    assert findings[0].check == "leyline-types"
+    assert findings[0].rule == "stale-whitelist"
+    assert findings[0].file == "src/esper/simic/rewards/reward_telemetry.py"
+
+
+def test_parse_leyline_output_records_active_type_boundary_violations() -> None:
+    output = """
+3 violation(s) found:
+
+  ERROR: src/esper/simic/agent/rollout_buffer.py:51: dataclass 'RollbackPenaltyResult' not in leyline or whitelist
+
+To fix: either move the type to leyline/, or add it to leyline_boundaries.yaml
+"""
+
+    findings = parse_leyline_output(output)
+
+    assert [finding.key for finding in findings] == [
+        "src/esper/simic/agent/rollout_buffer.py:dataclass:RollbackPenaltyResult"
+    ]
+    assert findings[0].line == 51
+    assert findings[0].rule == "dataclass"
+    assert findings[0].message == (
+        "dataclass RollbackPenaltyResult not in leyline or whitelist"
+    )
+
+
+def test_parse_defensive_output_records_violation_keys() -> None:
+    output = """
+1 VIOLATION(S) FOUND:
+
+  src/esper/foo.py:12: getattr in load_config()
+    Code: getattr(config, "missing")
+    Key:  src/esper/foo.py:load_config:getattr
+
+To fix:
+  1. PREFERRED: Remove the defensive pattern and fix the underlying issue
+"""
+
+    findings = parse_defensive_output(output)
+
+    assert [finding.key for finding in findings] == [
+        "src/esper/foo.py:load_config:getattr"
+    ]
+    assert findings[0].check == "defensive-patterns"
+    assert findings[0].file == "src/esper/foo.py"
+    assert findings[0].line == 12
+    assert findings[0].rule == "getattr"
+
+
+def test_parse_defensive_output_records_stale_whitelist_entries() -> None:
+    output = """
+STALE WHITELIST ENTRIES FOUND:
+
+  src/esper/foo.py:load_config:getattr
+
+To fix: remove or update these keys in defensive_patterns.yaml
+"""
+
+    findings = parse_defensive_output(output)
+
+    assert [finding.key for finding in findings] == [
+        "src/esper/foo.py:load_config:getattr"
+    ]
+    assert findings[0].file == "src/esper/foo.py"
+    assert findings[0].rule == "stale-whitelist"
+
+
+def test_build_phase_a_report_blocks_leyline_retirement_without_class_kind_metadata(
+    tmp_path: Path,
+) -> None:
+    wardline_output = tmp_path / "wardline.jsonl"
+    wardline_output.write_text("")
+    capabilities = LoomweaveCapabilities(
+        db_path=tmp_path / "loomweave.db",
+        database_present=True,
+        class_contract_kind_present=False,
+        module_import_edges_present=True,
+        module_cycles=[],
+    )
+
+    report = build_phase_a_report(
+        wardline_output=wardline_output,
+        loomweave=capabilities,
+        defensive_findings=[],
+        leyline_findings=[],
+    )
+
+    checks = {check["check"]: check for check in report["checks"]}
+    assert checks["leyline-types"]["replacement_ready"] is False
+    assert checks["leyline-types"]["blockers"][:1] == [
+        "Loomweave class_contract_kind metadata is not present; keep lint_leyline_types.py blocking."
+    ]
+    assert checks["leyline-types"]["retirement_gate"]["satisfied"] is False
+
+
+def test_build_phase_a_report_marks_defensive_patterns_unready_without_rule_mapping(
+    tmp_path: Path,
+) -> None:
+    wardline_output = tmp_path / "wardline.jsonl"
+    wardline_output.write_text("")
+    capabilities = LoomweaveCapabilities(
+        db_path=tmp_path / "loomweave.db",
+        database_present=True,
+        class_contract_kind_present=True,
+        module_import_edges_present=True,
+        module_cycles=[],
+    )
+
+    report = build_phase_a_report(
+        wardline_output=wardline_output,
+        loomweave=capabilities,
+        defensive_findings=[],
+        leyline_findings=[],
+    )
+
+    checks = {check["check"]: check for check in report["checks"]}
+    assert checks["defensive-patterns"]["replacement_ready"] is False
+    assert checks["defensive-patterns"]["blockers"][:1] == [
+        "Wardline emitted no defensive-pattern rule mapping; keep lint_defensive_patterns.py blocking."
+    ]
+    assert checks["defensive-patterns"]["retirement_gate"]["satisfied"] is False
+
+
+def test_build_phase_a_report_never_marks_replacement_ready_during_shadow_burn_in(
+    tmp_path: Path,
+) -> None:
+    wardline_output = tmp_path / "wardline.jsonl"
+    wardline_output.write_text('{"rule_id":"WLN-DEFENSIVE-PATTERN"}\n')
+    capabilities = LoomweaveCapabilities(
+        db_path=tmp_path / "loomweave.db",
+        database_present=True,
+        class_contract_kind_present=True,
+        module_import_edges_present=True,
+        module_cycles=[],
+    )
+
+    report = build_phase_a_report(
+        wardline_output=wardline_output,
+        loomweave=capabilities,
+        defensive_findings=[],
+        leyline_findings=[],
+    )
+
+    checks = {check["check"]: check for check in report["checks"]}
+    assert checks["defensive-patterns"]["shadow_signal_ready"] is True
+    assert checks["leyline-types"]["shadow_signal_ready"] is True
+    assert checks["module-cycles"]["shadow_signal_ready"] is True
+    assert checks["defensive-patterns"]["replacement_ready"] is False
+    assert checks["leyline-types"]["replacement_ready"] is False
+    assert checks["module-cycles"]["replacement_ready"] is False
+
+
+def test_build_phase_a_report_flags_missing_wardline_artifact(tmp_path: Path) -> None:
+    wardline_output = tmp_path / "missing-wardline.jsonl"
+    capabilities = LoomweaveCapabilities(
+        db_path=tmp_path / "loomweave.db",
+        database_present=True,
+        class_contract_kind_present=True,
+        module_import_edges_present=True,
+        module_cycles=[],
+    )
+
+    report = build_phase_a_report(
+        wardline_output=wardline_output,
+        loomweave=capabilities,
+        defensive_findings=[],
+        leyline_findings=[],
+    )
+
+    checks = {check["check"]: check for check in report["checks"]}
+    assert checks["defensive-patterns"]["blockers"][0] == (
+        "Wardline artifact is missing; inspect the Wardline shadow step before evaluating defensive-pattern parity."
+    )
+
+
+def test_inspect_loomweave_db_reports_import_edges_and_missing_class_kind(
+    tmp_path: Path,
+) -> None:
+    db_path = tmp_path / "loomweave.db"
+    import sqlite3
+
+    connection = sqlite3.connect(db_path)
+    connection.executescript(
+        """
+        create table entities (
+            id text primary key,
+            kind text not null,
+            name text not null,
+            properties text not null
+        );
+        create table edges (
+            kind text not null,
+            from_id text not null,
+            to_id text not null
+        );
+        insert into entities values
+            ('python:module:a', 'module', 'a', '{}'),
+            ('python:module:b', 'module', 'b', '{}'),
+            ('python:class:a.Payload', 'class', 'a.Payload', '{}');
+        insert into edges values
+            ('imports', 'python:module:a', 'python:module:b');
+        """
+    )
+    connection.close()
+
+    capabilities = inspect_loomweave_db(db_path)
+
+    assert capabilities.database_present is True
+    assert capabilities.module_import_edges_present is True
+    assert capabilities.class_contract_kind_present is False
+    assert capabilities.module_cycles == []


### PR DESCRIPTION
## Summary

Lands the **Weft Phase A CI migration** — rescued from an uncommitted worktree, evaluated merge-ready against `0.1.1`.

- Non-blocking **`weft-shadow`** GitHub Actions job runs the Weft tool suite (wardline / loomweave / legis / warpline) in shadow mode (job- and step-level `continue-on-error`, pinned tool versions, artifacts always uploaded).
- `src/esper/utils/weft_parity.py` + `scripts/ci_weft_parity.py`: normalize homegrown lint output (defensive-patterns, leyline-types) and Loomweave DB introspection (incl. a Tarjan SCC module-cycle detector) into a versioned `esper-weft-parity-v1` report.
- **Safety invariant:** the parity report can never mark a homegrown gate `replacement_ready` during burn-in — no existing gate is retired by this PR.
- Drops two genuinely-unused imports in `action_execution.py`; `PLAN_TRACKER.md` updated additively.

## Provenance / why now

This work existed only as uncommitted changes in a stale worktree. It was rescued onto a branch, then evaluated by an isolated trial-merge against `0.1.1`:
- The branch's `gpu_sync_whitelist.yaml` / `leyline_boundaries.yaml` edits were **stale** (the old two-`.item()` rollback whitelist + already-landed leyline-contract moves) and were **dropped** at merge — resolved to `0.1.1`'s side (the single `run_update:tolist` sync entry).
- The 5 feature/source/test files applied with zero conflict.

## Verification (against the merged tree)

- `pytest tests/utils/test_weft_parity.py tests/simic/training/test_run_phase_characterization.py tests/simic/training/test_action_execution_rollback.py` → **25 passed**
- `lint_gpu_sync.py` → 0 violations / 0 stale · `lint_leyline_types.py` → 0 stale · `lint_defensive_patterns.py` → 0 violations
- `scripts/ci_weft_parity.py` end-to-end → exit 0, valid `esper-weft-parity-v1` report, all checks `replacement_ready: false`

## Notes

- Phase A is observe-only by design (shadow burn-in); the parity step does not pass `--fail-on-homegrown-only`.
- `--history-count` is accepted but a documented no-op stub for Phase A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)